### PR TITLE
Add env template for Next.js site

### DIFF
--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -1,0 +1,3 @@
+# Brain Game Website Environment Template
+NEXT_PUBLIC_API_URL=https://api.braingame.dev
+NEXT_PUBLIC_ANALYTICS_ID=your-analytics-id

--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- allow env examples in website .gitignore
- add `.env.example` with API and analytics variables

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685085692fa48320a090c6cfc7784cd2