### PR TITLE
Implement TextInput variants

### DIFF
--- a/packages/bgui/TextInput/TextInput.tsx
+++ b/packages/bgui/TextInput/TextInput.tsx
@@ -1,23 +1,80 @@
-import { TextInput as RNTextInput } from "react-native";
+import { TextInput as RNTextInput, StyleSheet, View } from "react-native";
+import { Colors } from "../../utils/constants/Colors";
+import { Tokens } from "../../utils/constants/Tokens";
 import { useThemeColor } from "../../utils/hooks/useThemeColor";
+import { Icon } from "../Icon";
 import type { TextInputProps } from "./types";
 
-export const TextInput = ({ style, ...rest }: TextInputProps) => {
-	const color = useThemeColor("text");
+export const TextInput = ({
+	style,
+	leftIcon,
+	rightIcon,
+	variant = "standard",
+	onValueChange,
+	value,
+	"aria-label": ariaLabel,
+	"aria-describedby": ariaDescribedBy,
+	editable = true,
+	...rest
+}: TextInputProps) => {
+	const textColor = useThemeColor("text");
 	const placeholderColor = useThemeColor("textSecondary");
+	const backgroundColor = variant === "flat" ? "transparent" : useThemeColor("background");
+	const baseBorderColor = useThemeColor("border");
+	const borderColor = variant === "error" ? Colors.universal.negative : baseBorderColor;
 
 	return (
-		<RNTextInput
+		<View
 			style={[
-				{
-					color,
-					borderColor: useThemeColor("border"),
-					backgroundColor: useThemeColor("background"),
-				},
+				styles.container,
+				variant === "standard" && { borderWidth: 1 },
+				variant === "flat" && { borderBottomWidth: 1 },
+				variant === "error" && { borderWidth: 1 },
+				{ borderColor, backgroundColor },
+				!editable && styles.disabled,
 				style,
 			]}
-			placeholderTextColor={placeholderColor}
-			{...rest}
-		/>
+			accessible
+			accessibilityLabel={ariaLabel}
+			accessibilityHint={ariaDescribedBy}
+		>
+			{leftIcon && (
+				<Icon name={leftIcon} size={"secondary"} color={textColor} style={styles.icon} />
+			)}
+			<RNTextInput
+				value={value}
+				onChangeText={onValueChange}
+				placeholderTextColor={placeholderColor}
+				editable={editable}
+				style={[styles.input, { color: textColor }]}
+				accessibilityLabel={ariaLabel}
+				accessibilityHint={ariaDescribedBy}
+				{...rest}
+			/>
+			{rightIcon && (
+				<Icon name={rightIcon} size={"secondary"} color={textColor} style={styles.icon} />
+			)}
+		</View>
 	);
 };
+
+const styles = StyleSheet.create({
+	container: {
+		flexDirection: "row",
+		alignItems: "center",
+		paddingHorizontal: Tokens.s,
+		paddingVertical: Tokens.xs,
+		borderRadius: Tokens.xs,
+	},
+	input: {
+		flex: 1,
+		fontSize: Tokens.m,
+		padding: 0,
+	},
+	icon: {
+		marginHorizontal: Tokens.xs,
+	},
+	disabled: {
+		opacity: 0.5,
+	},
+});

--- a/packages/bgui/TextInput/types.ts
+++ b/packages/bgui/TextInput/types.ts
@@ -1,6 +1,12 @@
 import type { TextInputProps as RNTextInputProps } from "react-native";
 
 // Enterprise-grade TypeScript interfaces
-export interface TextInputProps extends RNTextInputProps {
-	// Additional custom props can be added here
+export interface TextInputProps extends Omit<RNTextInputProps, "onChangeText"> {
+	value: string;
+	onValueChange: (value: string) => void;
+	variant?: "standard" | "flat" | "error";
+	leftIcon?: string;
+	rightIcon?: string;
+	"aria-label"?: string;
+	"aria-describedby"?: string;
 }


### PR DESCRIPTION
## Summary
- enhance TextInput with standard, flat, and error variants
- add optional left/right icons
- wire accessibility props for labels and descriptions

## Testing
- `pnpm --filter @braingame/bgui lint`
- `pnpm --filter @braingame/bgui test`
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6b14d2483208406c6f0678b8267