### PR TITLE
Add Icon component implementation

### DIFF
--- a/packages/bgui/src/components/Icon/Icon.tsx
+++ b/packages/bgui/src/components/Icon/Icon.tsx
@@ -1,0 +1,37 @@
+import { Tokens } from "@braingame/utils/constants/Tokens";
+import { useThemeColor } from "@braingame/utils/hooks/useThemeColor";
+import { FA6Style, FontAwesome6 } from "@expo/vector-icons";
+import type { IconProps } from "./types";
+
+const sizeMap = {
+	sm: Tokens.s,
+	md: Tokens.l,
+	lg: Tokens.xl,
+} as const;
+
+export function Icon({
+	name,
+	variant = "regular",
+	size = "md",
+	color,
+	decorative = false,
+	"aria-label": ariaLabel,
+	style,
+}: IconProps) {
+	const iconSize = typeof size === "number" ? size : sizeMap[size];
+	const iconColor = useThemeColor(color ?? "icon");
+	const fontFamily =
+		variant === "solid" ? FA6Style.solid : variant === "brand" ? FA6Style.brand : FA6Style.regular;
+
+	return (
+		<FontAwesome6
+			name={name}
+			size={iconSize}
+			color={iconColor}
+			accessibilityElementsHidden={decorative}
+			accessibilityRole="image"
+			accessibilityLabel={decorative ? undefined : ariaLabel}
+			style={[{ fontFamily }, style]}
+		/>
+	);
+}

--- a/packages/bgui/src/components/Icon/index.ts
+++ b/packages/bgui/src/components/Icon/index.ts
@@ -1,0 +1,2 @@
+export { Icon } from "./Icon";
+export type { IconProps, IconVariant, IconSize, ThemeColor } from "./types";

--- a/packages/bgui/src/components/Icon/types.ts
+++ b/packages/bgui/src/components/Icon/types.ts
@@ -1,0 +1,16 @@
+import type { Colors } from "@braingame/utils/constants/Colors";
+import type { StyleProp, ViewStyle } from "react-native";
+
+export type IconVariant = "solid" | "regular" | "brand";
+export type IconSize = "sm" | "md" | "lg";
+export type ThemeColor = keyof typeof Colors.light & keyof typeof Colors.dark;
+
+export interface IconProps {
+	name: string;
+	variant?: IconVariant;
+	size?: IconSize | number;
+	color?: ThemeColor;
+	decorative?: boolean;
+	"aria-label"?: string;
+	style?: StyleProp<ViewStyle>;
+}


### PR DESCRIPTION
## Summary
- implement enterprise Icon component

## Testing
- `pnpm --filter "@braingame/bgui" lint`
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6b8f9f08320bef283efc5ac82ca