### PR TITLE
Add BGUI Card component

### DIFF
--- a/packages/bgui/src/components/Card/Card.tsx
+++ b/packages/bgui/src/components/Card/Card.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { Platform, Pressable, View as RNView, type ViewStyle } from "react-native";
+import { Tokens } from "../../../../utils/constants/Tokens";
+import { useThemeColor } from "../../../../utils/hooks/useThemeColor";
+import type { CardProps } from "./types";
+
+const paddingMap = {
+	none: 0,
+	small: Tokens.s,
+	medium: Tokens.m,
+	large: Tokens.l,
+} as const;
+
+export const Card = ({
+	children,
+	variant = "basic",
+	padding = "medium",
+	elevation = 0,
+	onPress,
+	style,
+	...rest
+}: CardProps) => {
+	const backgroundColor = useThemeColor("card");
+	const [isHovered, setIsHovered] = useState(false);
+
+	const baseStyle: ViewStyle = {
+		backgroundColor,
+		padding: paddingMap[padding],
+		borderRadius: Tokens.m,
+		elevation,
+	};
+
+	if (variant === "interactive" || onPress) {
+		return (
+			<Pressable
+				onPress={onPress}
+				{...(Platform.OS === "web" && variant === "interactive"
+					? { onHoverIn: () => setIsHovered(true), onHoverOut: () => setIsHovered(false) }
+					: {})}
+				style={[
+					baseStyle,
+					variant === "interactive" && isHovered && Platform.OS === "web"
+						? { opacity: 0.9, cursor: "pointer" }
+						: null,
+					style,
+				]}
+				{...rest}
+			>
+				{children}
+			</Pressable>
+		);
+	}
+
+	return (
+		<RNView style={[baseStyle, style]} {...rest}>
+			{children}
+		</RNView>
+	);
+};

--- a/packages/bgui/src/components/Card/index.tsx
+++ b/packages/bgui/src/components/Card/index.tsx
@@ -1,0 +1,2 @@
+export { Card } from "./Card";
+export type { CardProps } from "./types";

--- a/packages/bgui/src/components/Card/types.ts
+++ b/packages/bgui/src/components/Card/types.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+import type { ViewProps as RNViewProps } from "react-native";
+
+export interface CardProps extends RNViewProps {
+	children?: ReactNode;
+	variant?: "basic" | "interactive";
+	padding?: "none" | "small" | "medium" | "large";
+	elevation?: number;
+	onPress?: () => void;
+}


### PR DESCRIPTION
## Summary
- implement Card component and types
- support basic and interactive variants
- allow padding, elevation, and onPress

## Testing
- `npx biome check packages/bgui/src/components/Card`
- `pnpm test --silent` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6c0bee48320bdfa806d8e2597f7