### PR TITLE
Add Toast component

### DIFF
--- a/packages/bgui/src/components/Toast/Toast.tsx
+++ b/packages/bgui/src/components/Toast/Toast.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
+import { View } from '../../../View';
+import { Text } from '../../../Text';
+import { Tokens } from '../../../../utils/constants/Tokens';
+import { Colors } from '../../../../utils/constants/Colors';
+import { useThemeColor } from '../../../../utils/hooks/useThemeColor';
+import type { ToastProps } from './types';
+
+const DEFAULT_DURATION = 3000;
+
+const typeColorMap = {
+  success: Colors.universal.positive,
+  warning: Colors.universal.warn,
+  error: Colors.universal.negative,
+  info: Colors.universal.primary,
+};
+
+export const Toast = ({
+  message,
+  type = 'info',
+  duration = DEFAULT_DURATION,
+  actionLabel,
+  onActionPress,
+  variant = 'simple',
+}: ToastProps) => {
+  const [visible, setVisible] = useState(true);
+  const backgroundColor = typeColorMap[type];
+  const textColor = useThemeColor('text');
+
+  useEffect(() => {
+    AccessibilityInfo.announceForAccessibility(message);
+    const id = setTimeout(() => setVisible(false), duration);
+    return () => clearTimeout(id);
+  }, [duration, message]);
+
+  if (!visible) return null;
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor }]}
+      accessibilityLiveRegion="polite"
+      accessibilityRole="alert"
+    >
+      <Text style={[styles.message, { color: textColor }]}>{message}</Text>
+      {variant === 'with-action' && actionLabel && onActionPress && (
+        <Pressable onPress={onActionPress} style={styles.actionButton}>
+          <Text style={[styles.actionText, { color: textColor }]}>{actionLabel}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Tokens.m,
+    paddingVertical: Tokens.s,
+    borderRadius: Tokens.s,
+    margin: Tokens.s,
+  },
+  message: {
+    flex: 1,
+    marginRight: Tokens.s,
+  },
+  actionButton: {
+    paddingHorizontal: Tokens.s,
+    paddingVertical: Tokens.xs,
+  },
+  actionText: {
+    fontWeight: '600',
+  },
+});

--- a/packages/bgui/src/components/Toast/index.tsx
+++ b/packages/bgui/src/components/Toast/index.tsx
@@ -1,0 +1,2 @@
+export { Toast } from './Toast';
+export type { ToastProps } from './types';

--- a/packages/bgui/src/components/Toast/types.ts
+++ b/packages/bgui/src/components/Toast/types.ts
@@ -1,0 +1,14 @@
+export interface ToastProps {
+  /** Message to announce inside the toast */
+  message: string;
+  /** Visual style of the toast */
+  type?: 'success' | 'warning' | 'error' | 'info';
+  /** Auto dismiss duration in milliseconds */
+  duration?: number;
+  /** Optional action button label */
+  actionLabel?: string;
+  /** Callback when action button is pressed */
+  onActionPress?: () => void;
+  /** Toast variant */
+  variant?: 'simple' | 'with-action';
+}


### PR DESCRIPTION
## Summary
- implement Toast component with simple and with-action variants
- include accessibility announcements

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6cd12748320a327062bdfb17c87