### PR TITLE
Add Checkbox component to BGUI

### DIFF
--- a/packages/bgui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/bgui/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,56 @@
+import { Tokens } from "@braingame/utils/constants/Tokens";
+import { useThemeColor } from "@braingame/utils/hooks/useThemeColor";
+import { Pressable, View } from "react-native";
+import { Icon } from "../../../Icon";
+import { Text } from "../../../Text";
+import type { CheckboxProps } from "./types";
+
+export const Checkbox = ({
+	checked,
+	onValueChange,
+	children,
+	indeterminate = false,
+	disabled,
+	"aria-label": ariaLabel,
+	"aria-describedby": ariaDescribedBy,
+}: CheckboxProps) => {
+	const borderColor = useThemeColor("border");
+	const bg = useThemeColor("background");
+	const accent = useThemeColor("text");
+
+	const handlePress = () => {
+		if (disabled) return;
+		onValueChange(!checked);
+	};
+
+	const iconColor = bg;
+
+	return (
+		<Pressable
+			onPress={handlePress}
+			accessibilityRole="checkbox"
+			accessibilityState={{ checked: indeterminate ? "mixed" : checked, disabled }}
+			accessibilityLabel={ariaLabel}
+			{...(ariaDescribedBy ? { "aria-describedby": ariaDescribedBy } : {})}
+			style={{ flexDirection: "row", alignItems: "center", opacity: disabled ? 0.5 : 1 }}
+		>
+			<View
+				style={{
+					width: Tokens.l,
+					height: Tokens.l,
+					borderRadius: 4,
+					borderWidth: 1,
+					borderColor,
+					alignItems: "center",
+					justifyContent: "center",
+					backgroundColor: checked || indeterminate ? accent : bg,
+				}}
+			>
+				{(checked || indeterminate) && (
+					<Icon name={indeterminate ? "minus" : "check"} size="sm" color={iconColor} />
+				)}
+			</View>
+			{children && <Text style={{ marginLeft: Tokens.s }}>{children}</Text>}
+		</Pressable>
+	);
+};

--- a/packages/bgui/src/components/Checkbox/index.ts
+++ b/packages/bgui/src/components/Checkbox/index.ts
@@ -1,0 +1,2 @@
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps } from "./types";

--- a/packages/bgui/src/components/Checkbox/types.ts
+++ b/packages/bgui/src/components/Checkbox/types.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export interface CheckboxProps {
+	checked: boolean;
+	onValueChange: (value: boolean) => void;
+	children?: ReactNode;
+	indeterminate?: boolean;
+	disabled?: boolean;
+	"aria-label"?: string;
+	"aria-describedby"?: string;
+}


### PR DESCRIPTION
## Summary
- implement enterprise-grade Checkbox with indeterminate support
- support labels and accessibility props

## Testing
- `pnpm --filter @braingame/bgui lint`
- `pnpm --filter @braingame/bgui test`
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6f55df0832081f90e1550470bd6