### PR TITLE
Add Switch component

### DIFF
--- a/packages/bgui/src/components/Switch/Switch.tsx
+++ b/packages/bgui/src/components/Switch/Switch.tsx
@@ -1,0 +1,83 @@
+import { Colors, Tokens } from "@braingame/utils/constants";
+import { useThemeColor } from "@braingame/utils/hooks";
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import type { SwitchProps } from "./types";
+
+const PADDING = 2;
+
+export const Switch = ({
+	value,
+	onValueChange,
+	disabled = false,
+	variant = "standard",
+	style,
+	"aria-label": ariaLabel,
+	"aria-describedby": ariaDescribedby,
+}: SwitchProps) => {
+	const activeColor = Colors.universal.primary;
+	const inactiveColor = useThemeColor("button");
+	const trackStyles = variant === "compact" ? styles.compactTrack : styles.track;
+	const knobStyles = variant === "compact" ? styles.compactKnob : styles.knob;
+	const width = variant === "compact" ? Tokens.xl : Tokens.xxl;
+	const knobSize = variant === "compact" ? Tokens.s : Tokens.m;
+	const translateX = width - knobSize - PADDING * 2;
+
+	return (
+		<Pressable
+			role="switch"
+			accessibilityRole="switch"
+			accessibilityState={{ checked: value, disabled }}
+			aria-label={ariaLabel}
+			aria-describedby={ariaDescribedby}
+			aria-checked={value}
+			aria-disabled={disabled}
+			onPress={() => onValueChange(!value)}
+			disabled={disabled}
+			style={[
+				trackStyles,
+				{
+					width,
+					backgroundColor: value ? activeColor : inactiveColor,
+					opacity: disabled ? 0.5 : 1,
+				},
+				style,
+			]}
+		>
+			<View
+				style={[
+					knobStyles,
+					{
+						transform: value ? [{ translateX }] : undefined,
+						backgroundColor: "#fff",
+					},
+				]}
+			/>
+		</Pressable>
+	);
+};
+
+const styles = StyleSheet.create({
+	track: {
+		height: Tokens.l,
+		borderRadius: Tokens.l / 2,
+		padding: PADDING,
+		justifyContent: "center",
+	},
+	knob: {
+		width: Tokens.m,
+		height: Tokens.m,
+		borderRadius: Tokens.m / 2,
+	},
+	compactTrack: {
+		height: Tokens.m,
+		borderRadius: Tokens.m / 2,
+		padding: PADDING,
+		justifyContent: "center",
+	},
+	compactKnob: {
+		width: Tokens.s,
+		height: Tokens.s,
+		borderRadius: Tokens.s / 2,
+	},
+});

--- a/packages/bgui/src/components/Switch/index.ts
+++ b/packages/bgui/src/components/Switch/index.ts
@@ -1,0 +1,2 @@
+export * from "./Switch";
+export type { SwitchProps } from "./types";

--- a/packages/bgui/src/components/Switch/types.ts
+++ b/packages/bgui/src/components/Switch/types.ts
@@ -1,0 +1,11 @@
+import type { ViewStyle } from "react-native";
+
+export interface SwitchProps {
+	value: boolean;
+	onValueChange: (value: boolean) => void;
+	disabled?: boolean;
+	variant?: "standard" | "compact";
+	style?: ViewStyle;
+	"aria-label"?: string;
+	"aria-describedby"?: string;
+}


### PR DESCRIPTION
## Summary
- implement `Switch` component with compact and standard variants

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6fc1940832081cb1e80065ce854