### PR TITLE
Add Alert component to BGUI

### DIFF
--- a/packages/bgui/index.ts
+++ b/packages/bgui/index.ts
@@ -10,6 +10,7 @@ export { Link } from "./Link";
 export { PageWrapper } from "./PageWrapper";
 export { TextInput } from "./TextInput";
 export { ErrorBoundary } from "./ErrorBoundary";
+export { Alert } from "./src/components/Alert";
 
 // Type Exports (Enterprise TypeScript interfaces)
 export type { ButtonProps } from "./Button/types";
@@ -20,3 +21,4 @@ export type { LinkProps } from "./Link/types";
 export type { PageWrapperProps } from "./PageWrapper/types";
 export type { TextInputProps } from "./TextInput/types";
 export type { ErrorBoundaryProps, ErrorInfo } from "./ErrorBoundary/types";
+export type { AlertProps, AlertType, AlertVariant } from "./src/components/Alert/types";

--- a/packages/bgui/src/components/Alert/Alert.tsx
+++ b/packages/bgui/src/components/Alert/Alert.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { Pressable, StyleSheet } from "react-native";
+import { Colors, Tokens } from "@braingame/utils";
+import { View } from "../../../View";
+import { Text } from "../../../Text";
+import { Icon } from "../../../Icon";
+import type { AlertProps } from "./types";
+
+export const Alert = ({
+        variant = "inline",
+        title,
+        message,
+        type = "info",
+        actions,
+        dismissible,
+        onDismiss,
+        style,
+}: AlertProps) => {
+        const [visible, setVisible] = useState(true);
+
+        if (!visible) {
+                return null;
+        }
+
+        const backgroundColorMap = {
+                info: Colors.universal.primaryFaded,
+                success: Colors.universal.positiveFaded,
+                warning: Colors.universal.warnFaded,
+                error: Colors.universal.negativeFaded,
+        } as const;
+        const borderColorMap = {
+                info: Colors.universal.primaryHalfFaded,
+                success: Colors.universal.positiveHalfFaded,
+                warning: Colors.universal.warnHalfFaded,
+                error: Colors.universal.negativeHalfFaded,
+        } as const;
+
+        const handleDismiss = () => {
+                setVisible(false);
+                if (onDismiss) {
+                        onDismiss();
+                }
+        };
+
+        return (
+                <View
+                        style={[
+                                styles.container,
+                                variant === "banner" && styles.banner,
+                                variant === "floating" && styles.floating,
+                                {
+                                        backgroundColor: backgroundColorMap[type],
+                                        borderColor: borderColorMap[type],
+                                },
+                                style,
+                        ]}
+                >
+                        <View style={styles.content}>
+                                {title && (
+                                        <Text type="subtitle" style={styles.title}>
+                                                {title}
+                                        </Text>
+                                )}
+                                <Text>{message}</Text>
+                                {actions && <View style={styles.actions}>{actions}</View>}
+                        </View>
+                        {dismissible && (
+                                <Pressable onPress={handleDismiss} style={styles.close} accessibilityRole="button" accessibilityLabel="Dismiss alert">
+                                        <Icon name="xmark" size="small" />
+                                </Pressable>
+                        )}
+                </View>
+        );
+};
+
+const styles = StyleSheet.create({
+        container: {
+                flexDirection: "row",
+                alignItems: "flex-start",
+                padding: Tokens.s,
+                borderWidth: 1,
+                borderRadius: Tokens.xs,
+                gap: Tokens.s,
+        },
+        banner: {
+                width: "100%",
+        },
+        floating: {
+                position: "absolute",
+                top: Tokens.l,
+                left: Tokens.l,
+                right: Tokens.l,
+                zIndex: 1000,
+                shadowColor: "#000",
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.2,
+                shadowRadius: 4,
+                elevation: 4,
+        },
+        content: {
+                flex: 1,
+        },
+        title: {
+                marginBottom: Tokens.xs,
+        },
+        actions: {
+                marginTop: Tokens.s,
+        },
+        close: {
+                marginLeft: Tokens.s,
+        },
+});

--- a/packages/bgui/src/components/Alert/index.tsx
+++ b/packages/bgui/src/components/Alert/index.tsx
@@ -1,0 +1,2 @@
+export { Alert } from "./Alert";
+export type { AlertProps, AlertType, AlertVariant } from "./types";

--- a/packages/bgui/src/components/Alert/types.ts
+++ b/packages/bgui/src/components/Alert/types.ts
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
+
+export type AlertVariant = "banner" | "inline" | "floating";
+export type AlertType = "info" | "success" | "warning" | "error";
+
+export interface AlertProps {
+        variant?: AlertVariant;
+        title?: string;
+        message: string;
+        type?: AlertType;
+        actions?: ReactNode;
+        dismissible?: boolean;
+        onDismiss?: () => void;
+        style?: StyleProp<ViewStyle>;
+}


### PR DESCRIPTION
## Summary
- implement `Alert` component in `packages/bgui/src/components/Alert`
- export the component and types from package index

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b71c82fc8320ae96bac6ee2615ca