### PR TITLE
feat(bgui): implement ActionList component

### DIFF
--- a/packages/bgui/src/components/ActionList/ActionList.tsx
+++ b/packages/bgui/src/components/ActionList/ActionList.tsx
@@ -1,0 +1,65 @@
+import { Children, cloneElement, isValidElement, useRef, useState } from "react";
+import { View } from "react-native";
+import { ActionListItem } from "./ActionListItem";
+import type { ActionListProps } from "./types";
+
+export const ActionList = ({
+	children,
+	selectable = false,
+	selectedItems,
+	onSelectionChange,
+	variant = "list",
+	"aria-label": ariaLabel,
+}: ActionListProps) => {
+	const [internalSelection, setInternalSelection] = useState<string[]>([]);
+	const isControlled = selectedItems !== undefined;
+	const selection = isControlled ? selectedItems || [] : internalSelection;
+	const itemRefs = useRef<Array<{ focus?: () => void } | null>>([]);
+
+	const handleSelect = (value: string) => {
+		const newSelection = selection.includes(value)
+			? selection.filter((v) => v !== value)
+			: [...selection, value];
+		if (!isControlled) {
+			setInternalSelection(newSelection);
+		}
+		onSelectionChange?.(newSelection);
+	};
+
+	const focusItem = (index: number) => {
+		const ref = itemRefs.current[index];
+		if (ref && typeof ref.focus === "function") {
+			ref.focus();
+		}
+	};
+
+	const enhancedChildren = Children.map(children, (child, index) => {
+		if (!isValidElement(child)) return child;
+		const typeInfo = child.type as { displayName?: string };
+		if (typeInfo.displayName === ActionListItem.displayName) {
+			const value = child.props.value ?? index.toString();
+			return cloneElement(child, {
+				ref: (node: { focus?: () => void } | null) => {
+					itemRefs.current[index] = node;
+				},
+				selectable,
+				selected: selectable && selection.includes(value),
+				onSelect: () => handleSelect(value),
+				onArrowNext: () => focusItem((index + 1) % itemRefs.current.length),
+				onArrowPrev: () =>
+					focusItem((index - 1 + itemRefs.current.length) % itemRefs.current.length),
+			});
+		}
+		return child;
+	});
+
+	return (
+		<View
+			accessibilityRole={variant === "menu" ? "menu" : "list"}
+			role={variant === "menu" ? "menu" : "list"}
+			aria-label={ariaLabel}
+		>
+			{enhancedChildren}
+		</View>
+	);
+};

--- a/packages/bgui/src/components/ActionList/ActionListDivider.tsx
+++ b/packages/bgui/src/components/ActionList/ActionListDivider.tsx
@@ -1,0 +1,15 @@
+import { View } from "react-native";
+import { useThemeColor } from "../../../../utils/hooks/useThemeColor";
+import type { ActionListDividerProps } from "./types";
+
+export const ActionListDivider = (_props: ActionListDividerProps) => {
+	const color = useThemeColor("border");
+	return (
+		<View
+			accessibilityRole="separator"
+			role="separator"
+			style={{ height: 1, backgroundColor: color, marginVertical: 4 }}
+		/>
+	);
+};
+ActionListDivider.displayName = "ActionListDivider";

--- a/packages/bgui/src/components/ActionList/ActionListItem.tsx
+++ b/packages/bgui/src/components/ActionList/ActionListItem.tsx
@@ -1,0 +1,79 @@
+import { type ComponentRef, type KeyboardEvent, forwardRef } from "react";
+import { Pressable } from "react-native";
+import { useThemeColor } from "../../../../utils/hooks/useThemeColor";
+import { Icon } from "../../../Icon";
+import { Text } from "../../../Text";
+import type { ActionListItemProps } from "./types";
+
+export const ActionListItem = forwardRef<ComponentRef<typeof Pressable>, ActionListItemProps>(
+	(
+		{
+			icon,
+			children,
+			onPress,
+			disabled,
+			selectable,
+			selected,
+			onSelect,
+			onArrowNext,
+			onArrowPrev,
+			...rest
+		},
+		ref,
+	) => {
+		const background = selected ? useThemeColor("buttonHovered") : "transparent";
+
+		const handlePress = () => {
+			onPress?.();
+			if (selectable) {
+				onSelect?.();
+			}
+		};
+
+		const handleKeyDown = (e: KeyboardEvent) => {
+			const evt = e as unknown as {
+				nativeEvent?: { key?: string };
+				key?: string;
+				preventDefault?: () => void;
+			};
+			const key = evt.nativeEvent?.key || evt.key;
+			if (key === "Enter" || key === " ") {
+				evt.preventDefault?.();
+				handlePress();
+			} else if (key === "ArrowDown") {
+				evt.preventDefault?.();
+				onArrowNext?.();
+			} else if (key === "ArrowUp") {
+				evt.preventDefault?.();
+				onArrowPrev?.();
+			}
+		};
+
+		return (
+			<Pressable
+				ref={ref}
+				accessibilityRole="menuitem"
+				role="menuitem"
+				aria-selected={selectable ? selected : undefined}
+				aria-disabled={disabled}
+				tabIndex={0}
+				onKeyDown={handleKeyDown}
+				onPress={handlePress}
+				disabled={disabled}
+				style={{
+					flexDirection: "row",
+					alignItems: "center",
+					padding: 8,
+					backgroundColor: background,
+					opacity: disabled ? 0.5 : 1,
+				}}
+				{...rest}
+			>
+				{icon && <Icon name={icon} style={{ marginRight: 8 }} />}
+				<Text>{children}</Text>
+			</Pressable>
+		);
+	},
+);
+
+ActionListItem.displayName = "ActionListItem";

--- a/packages/bgui/src/components/ActionList/index.ts
+++ b/packages/bgui/src/components/ActionList/index.ts
@@ -1,0 +1,8 @@
+export { ActionList } from "./ActionList";
+export { ActionListItem } from "./ActionListItem";
+export { ActionListDivider } from "./ActionListDivider";
+export type {
+	ActionListProps,
+	ActionListItemProps,
+	ActionListDividerProps,
+} from "./types";

--- a/packages/bgui/src/components/ActionList/types.ts
+++ b/packages/bgui/src/components/ActionList/types.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+export interface ActionListProps {
+	children: ReactNode;
+	selectable?: boolean;
+	selectedItems?: string[];
+	onSelectionChange?: (items: string[]) => void;
+	variant?: "menu" | "list" | "compact";
+	"aria-label"?: string;
+}
+
+export interface ActionListItemProps {
+	children: ReactNode;
+	value?: string;
+	icon?: string;
+	onPress?: () => void;
+	disabled?: boolean;
+	selectable?: boolean;
+	selected?: boolean;
+	onSelect?: () => void;
+	onArrowNext?: () => void;
+	onArrowPrev?: () => void;
+}
+
+export type ActionListDividerProps = Record<string, never>;


### PR DESCRIPTION
## Summary
- implement ActionList, ActionList.Item and ActionList.Divider
- include ARIA roles, keyboard navigation and selection logic

## Testing
- `pnpm --filter "@braingame/bgui" lint`
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b7222eec8320aa3ecc36989bd6db