### PR TITLE
Add Tooltip component

### DIFF
--- a/packages/bgui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bgui/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,100 @@
+import { Colors, Tokens, useThemeColor } from "@braingame/utils";
+import { ReactNode, useId, useRef, useState } from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import type { TooltipProps } from "./types";
+
+export const Tooltip = ({
+	content,
+	children,
+	placement = "top",
+	delay = 300,
+	variant = "dark",
+	disabled = false,
+}: TooltipProps) => {
+	const [visible, setVisible] = useState(false);
+	const timeoutRef = useRef<number>();
+	const tooltipId = useId();
+
+	const show = () => {
+		if (disabled) return;
+		timeoutRef.current = window.setTimeout(() => setVisible(true), delay);
+	};
+
+	const hide = () => {
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		setVisible(false);
+	};
+
+	const backgroundColor =
+		variant === "light"
+			? useThemeColor("card")
+			: variant === "info"
+				? Colors.universal.primary
+				: "rgba(0,0,0,0.85)";
+
+	const textColor = variant === "dark" ? "#fff" : useThemeColor("text");
+
+	return (
+		<View style={styles.container}>
+			<Pressable
+				onHoverIn={show}
+				onHoverOut={hide}
+				onFocus={show}
+				onBlur={hide}
+				{...(Platform.OS === "web" && { "aria-describedby": tooltipId })}
+			>
+				{children}
+			</Pressable>
+			{visible && (
+				<View
+					nativeID={tooltipId}
+					style={[styles.base, styles[placement], { backgroundColor }]}
+					accessibilityRole="text"
+					accessibilityLiveRegion="polite"
+				>
+					{typeof content === "string" ? (
+						<Text style={[styles.text, { color: textColor }]}>{content}</Text>
+					) : (
+						content
+					)}
+				</View>
+			)}
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		position: "relative",
+		alignSelf: "flex-start",
+	},
+	base: {
+		position: "absolute",
+		paddingHorizontal: Tokens.s,
+		paddingVertical: Tokens.xs,
+		borderRadius: Tokens.xs,
+		maxWidth: 200,
+		zIndex: 999,
+	},
+	text: {
+		fontSize: Tokens.s,
+	},
+	top: {
+		bottom: "100%",
+		marginBottom: Tokens.xs,
+	},
+	bottom: {
+		top: "100%",
+		marginTop: Tokens.xs,
+	},
+	left: {
+		right: "100%",
+		marginRight: Tokens.xs,
+	},
+	right: {
+		left: "100%",
+		marginLeft: Tokens.xs,
+	},
+});
+
+export default Tooltip;

--- a/packages/bgui/src/components/Tooltip/index.ts
+++ b/packages/bgui/src/components/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from "./Tooltip";
+export type { TooltipProps } from "./types";

--- a/packages/bgui/src/components/Tooltip/types.ts
+++ b/packages/bgui/src/components/Tooltip/types.ts
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
+
+export interface TooltipProps {
+	content: ReactNode | string;
+	children: ReactNode;
+	placement?: "top" | "bottom" | "left" | "right";
+	delay?: number;
+	variant?: "dark" | "light" | "info";
+	disabled?: boolean;
+	style?: StyleProp<ViewStyle>;
+}


### PR DESCRIPTION
## Summary
- implement Tooltip component with placement, delay, theming and a11y features

## Testing
- `npx biome lint packages/bgui/src/components/Tooltip --apply`
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b72d17488320b01d21012633aa15