### PR TITLE
Add accessible Tabs components

### DIFF
--- a/packages/bgui/src/components/Tabs/Panel.tsx
+++ b/packages/bgui/src/components/Tabs/Panel.tsx
@@ -1,0 +1,21 @@
+import { View } from "react-native";
+import { useTabsContext } from "./context";
+import { styles } from "./styles";
+import type { TabsPanelProps } from "./types";
+
+export const Panel = ({ children, value }: TabsPanelProps) => {
+        const { activeTab } = useTabsContext();
+        if (activeTab !== value) {
+                return null;
+        }
+        return (
+                <View
+                        accessibilityRole="tabpanel"
+                        nativeID={`panel-${value}`}
+                        aria-labelledby={`tab-${value}`}
+                        style={styles.panel}
+                >
+                        {children}
+                </View>
+        );
+};

--- a/packages/bgui/src/components/Tabs/Panels.tsx
+++ b/packages/bgui/src/components/Tabs/Panels.tsx
@@ -1,0 +1,6 @@
+import { View } from "react-native";
+import type { TabsPanelsProps } from "./types";
+
+export const Panels = ({ children }: TabsPanelsProps) => {
+        return <View>{children}</View>;
+};

--- a/packages/bgui/src/components/Tabs/Tab.tsx
+++ b/packages/bgui/src/components/Tabs/Tab.tsx
@@ -1,0 +1,44 @@
+import { forwardRef } from "react";
+import { Pressable } from "react-native";
+import { useTabsContext } from "./context";
+import { styles } from "./styles";
+import type { TabProps } from "./types";
+import { Text } from "../../../Text";
+
+export const Tab = forwardRef<Pressable, TabProps>(function Tab(
+        { children, value, disabled, tabRef },
+        ref,
+) {
+        const { activeTab, onValueChange, variant } = useTabsContext();
+        const isActive = activeTab === value;
+
+        const handlePress = () => {
+                if (!disabled) {
+                        onValueChange(value);
+                }
+        };
+
+        return (
+                <Pressable
+                        ref={(node) => {
+                                (ref as any)?.(node);
+                                tabRef?.(node);
+                        }}
+                        accessibilityRole="tab"
+                        accessibilityState={{ selected: isActive, disabled }}
+                        accessibilityLabel={typeof children === "string" ? children : undefined}
+                        nativeID={`tab-${value}`}
+                        aria-controls={`panel-${value}`}
+                        onPress={handlePress}
+                        style={[
+                                styles.tab,
+                                variant === "pills" && styles.pill,
+                                variant === "line" && isActive && styles.lineActive,
+                                variant === "enclosed" && isActive && styles.enclosedActive,
+                                variant === "pills" && isActive && styles.pillActive,
+                        ]}
+                >
+                        {typeof children === "string" ? <Text>{children}</Text> : children}
+                </Pressable>
+        );
+});

--- a/packages/bgui/src/components/Tabs/Tabs.tsx
+++ b/packages/bgui/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from "react";
+import { TabsContext } from "./context";
+import type { TabsProps } from "./types";
+import { List } from "./List";
+import { Tab } from "./Tab";
+import { Panels } from "./Panels";
+import { Panel } from "./Panel";
+
+function TabsBase({
+        children,
+        activeTab,
+        onValueChange,
+        scrollable,
+        variant = "line",
+}: TabsProps): ReactElement {
+        return (
+                <TabsContext.Provider value={{ activeTab, onValueChange, variant, scrollable }}>
+                        {children}
+                </TabsContext.Provider>
+        );
+}
+
+export const Tabs = Object.assign(TabsBase, {
+        List,
+        Tab,
+        Panels,
+        Panel,
+});

--- a/packages/bgui/src/components/Tabs/context.tsx
+++ b/packages/bgui/src/components/Tabs/context.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import type { TabsVariant } from "./types";
+
+interface TabsContextValue {
+        activeTab: string;
+        onValueChange: (value: string) => void;
+        variant: TabsVariant;
+        scrollable: boolean | undefined;
+}
+
+export const TabsContext = createContext<TabsContextValue | null>(null);
+
+export function useTabsContext() {
+        const ctx = useContext(TabsContext);
+        if (!ctx) {
+                throw new Error("Tabs components must be used within Tabs");
+        }
+        return ctx;
+}

--- a/packages/bgui/src/components/Tabs/index.ts
+++ b/packages/bgui/src/components/Tabs/index.ts
@@ -1,0 +1,13 @@
+export { Tabs } from "./Tabs";
+export { List as TabsList } from "./List";
+export { Tab as TabsTab } from "./Tab";
+export { Panels as TabsPanels } from "./Panels";
+export { Panel as TabsPanel } from "./Panel";
+export type {
+        TabsProps,
+        TabsListProps,
+        TabProps,
+        TabsPanelsProps,
+        TabsPanelProps,
+        TabsVariant,
+} from "./types";

--- a/packages/bgui/src/components/Tabs/styles.ts
+++ b/packages/bgui/src/components/Tabs/styles.ts
@@ -1,0 +1,34 @@
+import { StyleSheet } from "react-native";
+import { Colors } from "../../../utils/constants/Colors";
+import { Tokens } from "../../../utils/constants/Tokens";
+
+export const styles = StyleSheet.create({
+        list: {
+                flexDirection: "row",
+        },
+        scrollable: {
+                flexGrow: 0,
+        },
+        tab: {
+                paddingVertical: Tokens.s,
+                paddingHorizontal: Tokens.m,
+                marginRight: Tokens.s,
+        },
+        pill: {
+                borderRadius: Tokens.s,
+        },
+        lineActive: {
+                borderBottomWidth: 2,
+                borderColor: Colors.universal.primary,
+        },
+        enclosedActive: {
+                backgroundColor: Colors.universal.primaryFaded,
+                borderRadius: Tokens.xs,
+        },
+        pillActive: {
+                backgroundColor: Colors.universal.primary,
+        },
+        panel: {
+                paddingVertical: Tokens.m,
+        },
+});

--- a/packages/bgui/src/components/Tabs/types.ts
+++ b/packages/bgui/src/components/Tabs/types.ts
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+export type TabsVariant = "line" | "enclosed" | "pills";
+
+export interface TabsProps {
+        children: ReactNode;
+        activeTab: string;
+        onValueChange: (value: string) => void;
+        scrollable?: boolean;
+        variant?: TabsVariant;
+}
+
+export interface TabsListProps {
+        children: ReactNode;
+        scrollable?: boolean;
+}
+
+export interface TabProps {
+        children: ReactNode;
+        value: string;
+        disabled?: boolean;
+        tabRef?: (node: any) => void;
+}
+
+export interface TabsPanelsProps {
+        children: ReactNode;
+}
+
+export interface TabsPanelProps {
+        children: ReactNode;
+        value: string;
+}


### PR DESCRIPTION
## Summary
- implement new Tabs component set with variants
- add List, Tab, Panels and Panel subcomponents
- support ARIA roles and basic keyboard nav

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b732cc948320a5c40588d038a68d