### PR TITLE
feat(bgui): add Link component

### DIFF
--- a/packages/bgui/src/components/Link/Link.tsx
+++ b/packages/bgui/src/components/Link/Link.tsx
@@ -1,0 +1,62 @@
+import { Link as ExpoLink } from "expo-router";
+import { Linking, Platform, Pressable, StyleSheet } from "react-native";
+import { Tokens } from "../../../../utils/constants/Tokens";
+import { textStyles } from "../../../../utils/constants/styles";
+import { Text } from "../../../Text";
+import type { LinkProps } from "./types";
+
+const styles = StyleSheet.create({
+	standalone: {
+		paddingVertical: Tokens.xs,
+	},
+});
+
+export const Link = ({
+	children,
+	href,
+	onPress,
+	external = false,
+	disabled = false,
+	variant = "inline",
+	"aria-label": ariaLabel,
+	...rest
+}: LinkProps) => {
+	const label = external && ariaLabel ? `${ariaLabel} (opens in new window)` : ariaLabel;
+
+	const handlePress = () => {
+		if (disabled) return;
+		if (onPress) {
+			onPress();
+			return;
+		}
+		if (href) {
+			if (external || Platform.OS !== "web") {
+				Linking.openURL(href);
+			}
+		}
+	};
+
+	const text = <Text type="link">{children}</Text>;
+	const style = [textStyles.link, variant === "standalone" && styles.standalone];
+
+	if (href && !external && Platform.OS === "web") {
+		return (
+			<ExpoLink href={href} aria-label={label} style={style} {...rest}>
+				{children}
+			</ExpoLink>
+		);
+	}
+
+	return (
+		<Pressable
+			accessibilityRole="link"
+			accessibilityLabel={label}
+			onPress={handlePress}
+			disabled={disabled}
+			style={style}
+			{...rest}
+		>
+			{text}
+		</Pressable>
+	);
+};

--- a/packages/bgui/src/components/Link/index.ts
+++ b/packages/bgui/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export { Link } from "./Link";
+export type { LinkProps } from "./types";

--- a/packages/bgui/src/components/Link/types.ts
+++ b/packages/bgui/src/components/Link/types.ts
@@ -1,0 +1,12 @@
+import type { LinkProps as ExpoLinkProps } from "expo-router";
+import type { ReactNode } from "react";
+
+export interface LinkProps extends Omit<ExpoLinkProps, "href"> {
+	children: ReactNode;
+	href?: string;
+	onPress?: () => void;
+	external?: boolean;
+	disabled?: boolean;
+	variant?: "inline" | "standalone";
+	"aria-label"?: string;
+}


### PR DESCRIPTION
## Summary
- add `Link` component under `packages/bgui/src/components/Link`

## Testing
- `pnpm test --filter @braingame/bgui`
- `pnpm lint --filter @braingame/bgui` *(fails: Error: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851b75e46488320a0653d606dedc2fc