### PR TITLE
Implement Label component

### DIFF
--- a/packages/bgui/src/components/Label/Label.tsx
+++ b/packages/bgui/src/components/Label/Label.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Platform, Text as RNText, type TextStyle } from "react-native";
+import { Tokens } from "@braingame/utils/constants/Tokens";
+import type { LabelProps } from "./types";
+
+const sizeMap: Record<NonNullable<LabelProps["size"]>, number> = {
+    sm: Tokens.s,
+    md: Tokens.m,
+    lg: Tokens.l,
+};
+
+export const Label = ({
+    children,
+    htmlFor,
+    required = false,
+    size = "md",
+    variant = "standard",
+    style,
+}: LabelProps) => {
+    const baseStyle: TextStyle = {
+        fontSize: sizeMap[size],
+    };
+
+    if (variant === "floating") {
+        Object.assign(baseStyle, {
+            position: "absolute" as const,
+            top: -Tokens.s,
+            left: Tokens.s,
+            pointerEvents: "none" as const,
+        });
+    }
+
+    if (Platform.OS === "web") {
+        return (
+            <label htmlFor={htmlFor} style={style as React.CSSProperties}>
+                <RNText style={baseStyle as any}>
+                    {children}
+                    {required && (
+                        <RNText accessibilityElementsHidden accessibilityRole="none" style={{ color: "red" }}>
+                            *
+                        </RNText>
+                    )}
+                </RNText>
+            </label>
+        );
+    }
+
+    return (
+        <RNText
+            style={[baseStyle, style] as any}
+            nativeID={htmlFor ? `${htmlFor}-label` : undefined}
+        >
+            {children}
+            {required && (
+                <RNText accessibilityElementsHidden accessibilityRole="none" style={{ color: "red" }}>
+                    *
+                </RNText>
+            )}
+        </RNText>
+    );
+};

--- a/packages/bgui/src/components/Label/index.tsx
+++ b/packages/bgui/src/components/Label/index.tsx
@@ -1,0 +1,2 @@
+export { Label } from "./Label";
+export type { LabelProps } from "./types";

--- a/packages/bgui/src/components/Label/types.ts
+++ b/packages/bgui/src/components/Label/types.ts
@@ -1,0 +1,9 @@
+import type { ReactNode, CSSProperties } from "react";
+export interface LabelProps {
+    children: ReactNode;
+    htmlFor?: string;
+    required?: boolean;
+    size?: 'sm' | 'md' | 'lg';
+    variant?: 'standard' | 'floating';
+    style?: CSSProperties & any;
+}


### PR DESCRIPTION
## Summary
- add Label component with required/floating variants
- leverage Tokens for sizing
- associate labels with form controls via `htmlFor` on web and `nativeID` on native

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b757a92c8320ad48ef5a1027a4a0