### PR TITLE
Add Image component

### DIFF
--- a/packages/bgui/src/components/Image/Image.tsx
+++ b/packages/bgui/src/components/Image/Image.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { Image as RNImage, View, StyleSheet } from "react-native";
+import type { ImageProps } from "./types";
+
+export const Image = ({
+    src,
+    alt,
+    placeholder,
+    fallback,
+    aspectRatio,
+    objectFit = "cover",
+    variant = "responsive",
+    style,
+    ...rest
+}: ImageProps) => {
+    const [loaded, setLoaded] = useState(false);
+    const [error, setError] = useState(false);
+
+    if (error) {
+        return fallback ? <>{fallback}</> : null;
+    }
+
+    return (
+        <View
+            style={[
+                variant === "responsive" && styles.responsive,
+                aspectRatio !== undefined && { aspectRatio },
+                style,
+            ]}
+        >
+            {!loaded && placeholder}
+            <RNImage
+                source={{ uri: src }}
+                accessibilityLabel={alt}
+                onLoad={() => setLoaded(true)}
+                onError={() => setError(true)}
+                style={[StyleSheet.absoluteFill, { objectFit }]}
+                {...rest}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    responsive: {
+        width: "100%",
+    },
+});

--- a/packages/bgui/src/components/Image/index.tsx
+++ b/packages/bgui/src/components/Image/index.tsx
@@ -1,0 +1,3 @@
+// Enterprise-grade barrel export
+export { Image } from "./Image";
+export type { ImageProps } from "./types";

--- a/packages/bgui/src/components/Image/types.ts
+++ b/packages/bgui/src/components/Image/types.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import type { ImageProps as RNImageProps, StyleProp, ImageStyle } from "react-native";
+
+// Enterprise-grade TypeScript interfaces
+export interface ImageProps extends Omit<RNImageProps, "source"> {
+    src: string;
+    alt: string;
+    placeholder?: ReactNode;
+    fallback?: ReactNode;
+    aspectRatio?: number;
+    objectFit?: "cover" | "contain" | "fill";
+    variant?: "responsive" | "fixed";
+    style?: StyleProp<ImageStyle>;
+}


### PR DESCRIPTION
## Summary
- implement `Image` component with alt/fallback/placeholder
- support aspect ratio and responsive/fixed variants

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b76529c483209fe7919cc9af8e00