### PR TITLE
Add docs for BGUI component props

### DIFF
--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -31,6 +31,14 @@
   - AI-specific documentation is critical for effective human-AI collaboration.
 - **Next Steps**: The repository's documentation is now considered enterprise-grade. Ready for next development phase.
 
+### 17-06-2025 - Component Prop Docs
+- **Agent**: ChatGPT
+- **Tasks**: Document BGUI component props
+- **Completed**:
+  - Generated markdown files in `docs/components` for each component
+  - Added TODO entry tracking documentation progress
+- **Next Steps**: Expand docs as components evolve
+
 ### 17-06-2025 - Enterprise-Grade BGUI Component Plan
 - **Agent**: Claude Sonnet 4
 - **Tasks**: Review and enhance BGUI component plan for enterprise standards

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -59,6 +59,10 @@
   - [ ] Add visual testing
   - Status: Completed planning - comprehensive `docs/BGUI_COMPONENT_PLAN.md` with 28 enterprise-grade components, accessibility specs, and implementation roadmap
 
+- [ ] Component Prop Docs
+  - [ ] Document props for each BGUI component
+  - Status: in_progress (17-06-2025)
+
 - [ ] Environment Management
   - [ ] Create `.env.example` files (in progress)
   - [ ] Add validation with zod

--- a/docs/components/Button.md
+++ b/docs/components/Button.md
@@ -1,0 +1,11 @@
+# Button
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `text` | `string` | – |
+| `icon` | `string` | – |
+| `iconColor` | `string` | – |
+| `iconType` | `string` | – |
+| `onPress` | `() => void` | required |
+| `disabled` | `boolean` | – |
+

--- a/docs/components/ErrorBoundary.md
+++ b/docs/components/ErrorBoundary.md
@@ -1,0 +1,11 @@
+# ErrorBoundary
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `children` | `ReactNode` | required |
+| `fallback` | `ReactNode` | – |
+| `onError` | `(error: Error, info: ErrorInfo) => void` | – |
+| `resetOnPropsChange` | `boolean` | – |
+| `resetKeys` | `Array<string | number>` | – |
+| `isolate` | `boolean` | – |
+

--- a/docs/components/Icon.md
+++ b/docs/components/Icon.md
@@ -1,0 +1,10 @@
+# Icon
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `name` | `string` | required |
+| `size` | `IconSizeProps \| number` | `"secondary"` |
+| `color` | `string` | theme value |
+| `type` | `string` | `"fas"` |
+| `style` | `StyleProp<ViewStyle>` | – |
+

--- a/docs/components/Link.md
+++ b/docs/components/Link.md
@@ -1,0 +1,9 @@
+# Link
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `href` | `string` | required |
+| `text` | `string` | – |
+| `children` | `ReactNode` | – |
+| `...ExpoLinkProps` | `expo-router LinkProps` | – |
+

--- a/docs/components/PageWrapper.md
+++ b/docs/components/PageWrapper.md
@@ -1,0 +1,6 @@
+# PageWrapper
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `children` | `ReactNode` | required |
+

--- a/docs/components/Text.md
+++ b/docs/components/Text.md
@@ -1,0 +1,7 @@
+# Text
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `type` | `"display" | "title" | "subtitle" | "default" | "small" | "link"` | `"default"` |
+| `...RNTextProps` | `React Native TextProps` | – |
+

--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -1,0 +1,6 @@
+# TextInput
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `...RNTextInputProps` | `React Native TextInputProps` | – |
+

--- a/docs/components/View.md
+++ b/docs/components/View.md
@@ -1,0 +1,12 @@
+# View
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `type` | `"background" | "card" | "surface" | "mini-card"` | `"background"` |
+| `transparent` | `boolean` | – |
+| `rounded` | `boolean` | – |
+| `border` | `boolean` | – |
+| `hoverable` | `boolean` | – |
+| `grabbable` | `boolean` | – |
+| `...RNViewProps` | `React Native ViewProps` | – |
+


### PR DESCRIPTION
## Summary
- document BGUI component props under `docs/components`
- track new docs task in TODO
- log docs session in AI_CONTEXT

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851b7a01cd08320b3b1e921608cdf9b