### PR TITLE
Add design token usage report

### DIFF
--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -15,6 +15,15 @@
 ## 2. Session Summaries
 *All summaries are in reverse chronological order (newest first).*
 
+### 17-06-2025 - Design Token Audit
+- **Agent**: ChatGPT
+- **Tasks**: Catalog all design tokens used in `@brain-game/bgui`
+- **Completed**:
+  - Scanned components for `Colors` and `Tokens` references
+  - Generated `docs/TOKEN_USAGE.md`
+  - Updated `docs/TODO.md` with completion status
+- **Next Steps**: Integrate token report into design workflow
+
 ### 18-06-2025 - Full Documentation Overhaul
 - **Agent**: Claude 3.5 Sonnet
 - **Tasks**: Review and upgrade all project documentation to enterprise-grade standards.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -86,6 +86,10 @@
   - Reviewed and upgraded all project markdown files to enterprise-grade standards
   - Ensured all documentation is consistent, linked, and serves a clear purpose
   - Status: Completed @ 18-06-2025
+- [x] Design token usage report (17-06-2025)
+  - Documented all Colors and Tokens references in `packages/bgui`
+  - Added `docs/TOKEN_USAGE.md`
+  - Status: Completed @ 17-06-2025
 
 ## 📝 Notes for AI Agents
 - Always update status when working on tasks

--- a/docs/TOKEN_USAGE.md
+++ b/docs/TOKEN_USAGE.md
@@ -1,0 +1,22 @@
+# Token Usage Report
+
+This document catalogs every design token referenced in the BGUI component library (`packages/bgui`). Tokens come from [`packages/utils/constants`](../packages/utils/constants) and are consumed via helper functions and shared style files.
+
+## Component Matrix
+
+| Component | Colors Tokens | Spacing/Size Tokens |
+|-----------|---------------|--------------------|
+| **Button** | `button`, `buttonHovered` | `xs`, `m` |
+| **Icon** | `icon` | `xl`, `l`, `s` |
+| **Text** | `text`, `universal.primary` | `xxxl`, `xxl`, `l`, `m`, `xl`, `s` |
+| **TextInput** | `text`, `textSecondary`, `border`, `background` | – |
+| **View** | `background`, `card`, `border` | `m`, `s` |
+| **Link** | – | – |
+| **PageWrapper** | – | – |
+| **ErrorBoundary** | – | – |
+
+## Token Summary
+
+**Colors:** `button`, `buttonHovered`, `icon`, `text`, `textSecondary`, `border`, `background`, `card`, `universal.primary`
+
+**Tokens:** `xxxl`, `xxl`, `xl`, `l`, `m`, `s`, `xs`


### PR DESCRIPTION
## Summary
- document all design tokens used in `packages/bgui`
- track the audit task in TODO
- add session summary in AI_CONTEXT

## Testing
- `pnpm format:write`
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: missing expo tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6851b7aa2dd883209ed2ba21c871e1df