### PR TITLE
Add JSDoc to BGUI components

### DIFF
--- a/packages/bgui/Button/Button.tsx
+++ b/packages/bgui/Button/Button.tsx
@@ -6,6 +6,11 @@ import { Icon } from "../Icon";
 import { Text } from "../Text";
 import type { ButtonProps } from "./types";
 
+/**
+ * Render a theme-aware button.
+ *
+ * Provides hover states on web and supports optional icon-only mode.
+ */
 export const Button = ({ text, icon, iconColor, iconType, onPress, disabled }: ButtonProps) => {
 	const backgroundColor = useThemeColor("button");
 	const backgroundColorHovered = useThemeColor("buttonHovered");

--- a/packages/bgui/Button/types.ts
+++ b/packages/bgui/Button/types.ts
@@ -1,9 +1,31 @@
-// Enterprise-grade TypeScript interfaces
+/**
+ * Props for the {@link Button} component.
+ * Use these to customise the appearance and behaviour of a button.
+ */
 export interface ButtonProps {
+	/**
+	 * Text label to display inside the button.
+	 * Omit when using an icon-only button.
+	 */
 	text?: string;
+	/**
+	 * Optional icon name from the font library.
+	 */
 	icon?: string;
+	/**
+	 * Color of the optional icon.
+	 */
 	iconColor?: string;
+	/**
+	 * FontAwesome style prefix (e.g. `fas`).
+	 */
 	iconType?: string;
+	/**
+	 * Callback invoked when the user presses the button.
+	 */
 	onPress: () => void;
+	/**
+	 * Disable interaction and visually indicate inactive state.
+	 */
 	disabled?: boolean;
 }

--- a/packages/bgui/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/bgui/ErrorBoundary/ErrorBoundary.tsx
@@ -4,6 +4,11 @@ import { Text } from "../Text";
 import { View } from "../View";
 import type { ErrorBoundaryProps, ErrorBoundaryState, ErrorInfo } from "./types";
 
+/**
+ * React component that captures rendering errors in its child tree.
+ *
+ * Use this around critical areas to prevent the entire app from crashing.
+ */
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 	private resetTimeoutId: number | null = null;
 

--- a/packages/bgui/ErrorBoundary/types.ts
+++ b/packages/bgui/ErrorBoundary/types.ts
@@ -1,24 +1,39 @@
 import type { ReactNode } from "react";
 
-// Enterprise-grade TypeScript interfaces
+/** Information captured during an error boundary failure. */
 export interface ErrorInfo {
+	/** React component stack trace. */
 	componentStack: string;
+	/** Name of the boundary where the error occurred. */
 	errorBoundary?: string;
+	/** Stack trace for nested error boundaries. */
 	errorBoundaryStack?: string;
 }
 
+/** Internal state maintained by {@link ErrorBoundary}. */
 export interface ErrorBoundaryState {
+	/** Whether an error has been caught. */
 	hasError: boolean;
+	/** Captured error object. */
 	error: Error | null;
+	/** Additional error information. */
 	errorInfo: ErrorInfo | null;
+	/** Unique identifier generated for the error. */
 	errorId: string | null;
 }
 
+/** Props accepted by {@link ErrorBoundary}. */
 export interface ErrorBoundaryProps {
+	/** Child components that should be protected. */
 	children: ReactNode;
+	/** Custom fallback element to render on error. */
 	fallback?: ReactNode;
+	/** Optional callback when an error is captured. */
 	onError?: (error: Error, errorInfo: ErrorInfo) => void;
+	/** Reset the boundary when any prop changes. */
 	resetOnPropsChange?: boolean;
+	/** Keys that trigger a reset when changed. */
 	resetKeys?: Array<string | number>;
+	/** Isolate the boundary from parent contexts. */
 	isolate?: boolean;
 }

--- a/packages/bgui/Icon/Icon.tsx
+++ b/packages/bgui/Icon/Icon.tsx
@@ -3,6 +3,11 @@ import { getIconSize } from "../../utils/helpers/getIconSize";
 import { useThemeColor } from "../../utils/hooks/useThemeColor";
 import type { IconProps } from "./types";
 
+/**
+ * Generic icon component used throughout the app.
+ *
+ * Colors fall back to the theme and sizes are resolved via {@link getIconSize}.
+ */
 export const Icon = ({ name, size = "secondary", color, type = "fas", style }: IconProps) => {
 	const iconSize = getIconSize(size);
 	const iconColor = color ?? useThemeColor("icon");

--- a/packages/bgui/Icon/types.ts
+++ b/packages/bgui/Icon/types.ts
@@ -1,11 +1,18 @@
 import type { StyleProp, ViewStyle } from "react-native";
 import type { IconSizeProps } from "../../utils/constants/types";
 
-// Enterprise-grade TypeScript interfaces
+/**
+ * Props for the {@link Icon} component.
+ */
 export interface IconProps {
+	/** Name of the icon glyph. */
 	name: string;
+	/** Icon size key or explicit number of pixels. */
 	size?: IconSizeProps | number;
+	/** Optional color override. */
 	color?: string;
+	/** FontAwesome style prefix (e.g. `fas`). */
 	type?: string;
+	/** Additional style overrides. */
 	style?: StyleProp<ViewStyle>;
 }

--- a/packages/bgui/Link/Link.tsx
+++ b/packages/bgui/Link/Link.tsx
@@ -1,6 +1,9 @@
 import { Link as ExpoLink } from "expo-router";
 import type { LinkProps } from "./types";
 
+/**
+ * Wrapper around `expo-router` Link that supports optional text shorthand.
+ */
 export const Link = ({ href, text, children, ...rest }: LinkProps) => {
 	return (
 		<ExpoLink href={href} {...rest}>

--- a/packages/bgui/Link/types.ts
+++ b/packages/bgui/Link/types.ts
@@ -1,8 +1,12 @@
 import type { LinkProps as ExpoLinkProps } from "expo-router";
 import type { ReactNode } from "react";
 
-// Enterprise-grade TypeScript interfaces
+/**
+ * Props for the {@link Link} component.
+ */
 export interface LinkProps extends ExpoLinkProps {
+	/** Text content if not using `children`. */
 	text?: string;
+	/** Elements to render inside the link. */
 	children?: ReactNode;
 }

--- a/packages/bgui/PageWrapper/PageWrapper.tsx
+++ b/packages/bgui/PageWrapper/PageWrapper.tsx
@@ -3,6 +3,9 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { View } from "../View";
 import type { PageWrapperProps } from "./types";
 
+/**
+ * Provides safe area padding and base layout for each page.
+ */
 export const PageWrapper = ({ children }: PageWrapperProps) => {
 	return (
 		<SafeAreaProvider>

--- a/packages/bgui/PageWrapper/types.ts
+++ b/packages/bgui/PageWrapper/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
-// Enterprise-grade TypeScript interfaces
+/** Props for the {@link PageWrapper} layout component. */
 export interface PageWrapperProps {
+	/** Content to render inside the page wrapper. */
 	children: ReactNode;
 }

--- a/packages/bgui/Text/Text.tsx
+++ b/packages/bgui/Text/Text.tsx
@@ -3,6 +3,9 @@ import { textStyles } from "../../utils/constants/styles";
 import { useThemeColor } from "../../utils/hooks/useThemeColor";
 import type { TextProps } from "./types";
 
+/**
+ * Typography component that applies theme-based styles.
+ */
 export const Text = ({ type = "default", style, ...rest }: TextProps) => {
 	const color = useThemeColor("text");
 

--- a/packages/bgui/Text/types.ts
+++ b/packages/bgui/Text/types.ts
@@ -1,6 +1,9 @@
 import type { TextProps as RNTextProps } from "react-native";
 
-// Enterprise-grade TypeScript interfaces
+/**
+ * Props for the {@link Text} component.
+ */
 export interface TextProps extends RNTextProps {
+	/** Visual style of the text. */
 	type?: "display" | "title" | "subtitle" | "default" | "small" | "link";
 }

--- a/packages/bgui/TextInput/TextInput.tsx
+++ b/packages/bgui/TextInput/TextInput.tsx
@@ -2,6 +2,9 @@ import { TextInput as RNTextInput } from "react-native";
 import { useThemeColor } from "../../utils/hooks/useThemeColor";
 import type { TextInputProps } from "./types";
 
+/**
+ * Styled text input component that adapts to the current theme.
+ */
 export const TextInput = ({ style, ...rest }: TextInputProps) => {
 	const color = useThemeColor("text");
 	const placeholderColor = useThemeColor("textSecondary");

--- a/packages/bgui/TextInput/types.ts
+++ b/packages/bgui/TextInput/types.ts
@@ -1,6 +1,10 @@
 import type { TextInputProps as RNTextInputProps } from "react-native";
 
-// Enterprise-grade TypeScript interfaces
+/**
+ * Props for the {@link TextInput} component.
+ */
 export interface TextInputProps extends RNTextInputProps {
-	// Additional custom props can be added here
+	/**
+	 * Additional custom props can be added here in the future.
+	 */
 }

--- a/packages/bgui/View/View.tsx
+++ b/packages/bgui/View/View.tsx
@@ -5,6 +5,9 @@ import { viewStyles } from "../../utils/constants/styles";
 import { useThemeColor } from "../../utils/hooks/useThemeColor";
 import type { ViewProps } from "./types";
 
+/**
+ * Theme-aware container component used throughout layouts.
+ */
 export const View = ({
 	type = "background",
 	style,

--- a/packages/bgui/View/types.ts
+++ b/packages/bgui/View/types.ts
@@ -1,11 +1,19 @@
 import type { ViewProps as RNViewProps } from "react-native";
 
-// Enterprise-grade TypeScript interfaces
+/**
+ * Props for the theme-aware {@link View} container.
+ */
 export interface ViewProps extends RNViewProps {
+	/** Which theme surface this view represents. */
 	type?: "background" | "card" | "surface" | "mini-card";
+	/** Render with a transparent background. */
 	transparent?: boolean;
+	/** Apply a medium border radius. */
 	rounded?: boolean;
+	/** Display a 1px border using the theme color. */
 	border?: boolean;
+	/** Adds hover styles when used on web. */
 	hoverable?: boolean;
+	/** Set pointer cursor to indicate draggable content. */
 	grabbable?: boolean;
 }


### PR DESCRIPTION
## Summary
- document props for all BGUI components
- add component usage hints via JSDoc blocks

## Testing
- `pnpm -r run lint`
- `pnpm --filter "./packages/bgui" run test`

------
https://chatgpt.com/codex/tasks/task_e_6851b7dc6288832099d90ebe7fa44b55