### PR TITLE
Optimize turbo tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
 		"workspace:prune": "turbo prune",
 		"secrets:scan": "secretlint .",
 		"secrets:check": "secretlint --no-color .",
-		"ci": "pnpm install --frozen-lockfile && pnpm secrets:check && pnpm lint && pnpm typecheck && pnpm test && pnpm build",
-		"precommit": "lint-staged && pnpm secrets:check && pnpm test",
+                "quality": "turbo lint typecheck test",
+                "ci": "pnpm install --frozen-lockfile && pnpm secrets:check && pnpm quality && pnpm build",
+                "precommit": "lint-staged && pnpm secrets:check && pnpm quality",
 		"storybook": "echo 'Storybook is not yet implemented'"
 	},
 	"devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,26 +1,29 @@
 {
-	"$schema": "https://turbo.build/schema.json",
-	"tasks": {
-		"build": {
-			"dependsOn": ["^build"],
-			"outputs": [".next/**", "dist/**", "web-build/**"]
-		},
-		"dev": {
-			"persistent": true,
-			"cache": false
-		},
-		"lint": {
-			"dependsOn": ["^lint"]
-		},
-		"test": {
-			"dependsOn": ["^test"],
-			"outputs": ["coverage/**"]
-		},
-		"typecheck": {
-			"dependsOn": ["^typecheck"]
-		},
-		"clean": {
-			"cache": false
-		}
-	}
+        "$schema": "https://turbo.build/schema.json",
+        "globalDependencies": ["**/package.json", "pnpm-lock.yaml", "turbo.json"],
+        "tasks": {
+                "build": {
+                        "dependsOn": ["^build"],
+                        "outputs": [".next/**", "dist/**", "web-build/**"]
+                },
+                "dev": {
+                        "persistent": true,
+                        "cache": false
+                },
+                "lint": {
+                        "dependsOn": ["^lint"],
+                        "outputs": []
+                },
+                "test": {
+                        "dependsOn": ["^test"],
+                        "outputs": ["coverage/**"]
+                },
+                "typecheck": {
+                        "dependsOn": ["^typecheck"],
+                        "outputs": []
+                },
+                "clean": {
+                        "cache": false
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- add `quality` script to run lint, typecheck and tests in parallel
- update CI and precommit scripts to use new quality task
- configure turbo with global dependencies and explicit outputs

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851baaa894083208f3f4cf169b35678