### PR TITLE
Add BGUI usage snippets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,13 @@
 | [`BGUI_COMPONENT_PLAN.md`](./BGUI_COMPONENT_PLAN.md) | The detailed API and specification for our BGUI component library. |
 | [`SECURITY.md`](../SECURITY.md) | Our security policy, including how to report vulnerabilities. |
 
+## 📚 Component Snippets
+*Quick examples showing how to use our UI kit.*
+
+| Document | Description |
+|---|---|
+| [`snippets/`](./snippets) | Ready-to-use code snippets for each BGUI component. |
+
 ---
 
 ## 📈 Project Management & Strategy

--- a/docs/snippets/button.md
+++ b/docs/snippets/button.md
@@ -1,0 +1,11 @@
+# Button Usage
+
+```tsx
+import { Button } from '@brain-game/bgui';
+
+export function ButtonExample() {
+  return (
+    <Button text="Click me" onPress={() => console.log('pressed')} />
+  );
+}
+```

--- a/docs/snippets/errorboundary.md
+++ b/docs/snippets/errorboundary.md
@@ -1,0 +1,17 @@
+# ErrorBoundary Usage
+
+```tsx
+import { ErrorBoundary, Text } from '@brain-game/bgui';
+
+function ProblemChild() {
+  throw new Error('boom');
+}
+
+export function ErrorBoundaryExample() {
+  return (
+    <ErrorBoundary>
+      <ProblemChild />
+    </ErrorBoundary>
+  );
+}
+```

--- a/docs/snippets/icon.md
+++ b/docs/snippets/icon.md
@@ -1,0 +1,9 @@
+# Icon Usage
+
+```tsx
+import { Icon } from '@brain-game/bgui';
+
+export function IconExample() {
+  return <Icon name="check" size="md" />;
+}
+```

--- a/docs/snippets/link.md
+++ b/docs/snippets/link.md
@@ -1,0 +1,9 @@
+# Link Usage
+
+```tsx
+import { Link } from '@brain-game/bgui';
+
+export function LinkExample() {
+  return <Link href="/about" text="About Us" />;
+}
+```

--- a/docs/snippets/login-form.md
+++ b/docs/snippets/login-form.md
@@ -1,0 +1,29 @@
+# Login Form Example
+
+```tsx
+import { Button, TextInput, View } from '@brain-game/bgui';
+import { Checkbox } from '@brain-game/bgui';
+import { useState } from 'react';
+
+export function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
+
+  return (
+    <View style={{ gap: 8 }}>
+      <TextInput value={email} onChangeText={setEmail} placeholder="Email" />
+      <TextInput
+        value={password}
+        onChangeText={setPassword}
+        placeholder="Password"
+        secureTextEntry
+      />
+      <Checkbox checked={remember} onValueChange={setRemember}>
+        Remember me
+      </Checkbox>
+      <Button text="Login" onPress={() => {}} />
+    </View>
+  );
+}
+```

--- a/docs/snippets/pagewrapper.md
+++ b/docs/snippets/pagewrapper.md
@@ -1,0 +1,13 @@
+# PageWrapper Usage
+
+```tsx
+import { PageWrapper, Text } from '@brain-game/bgui';
+
+export default function Page() {
+  return (
+    <PageWrapper>
+      <Text>Welcome!</Text>
+    </PageWrapper>
+  );
+}
+```

--- a/docs/snippets/text.md
+++ b/docs/snippets/text.md
@@ -1,0 +1,9 @@
+# Text Usage
+
+```tsx
+import { Text } from '@brain-game/bgui';
+
+export function TextExample() {
+  return <Text type="title">Hello World</Text>;
+}
+```

--- a/docs/snippets/textinput.md
+++ b/docs/snippets/textinput.md
@@ -1,0 +1,13 @@
+# TextInput Usage
+
+```tsx
+import { TextInput } from '@brain-game/bgui';
+import { useState } from 'react';
+
+export function TextInputExample() {
+  const [value, setValue] = useState('');
+  return (
+    <TextInput value={value} onChangeText={setValue} placeholder="Enter text" />
+  );
+}
+```

--- a/docs/snippets/view.md
+++ b/docs/snippets/view.md
@@ -1,0 +1,13 @@
+# View Usage
+
+```tsx
+import { View } from '@brain-game/bgui';
+
+export function ViewExample() {
+  return (
+    <View style={{ padding: 16 }} rounded border>
+      {/* content */}
+    </View>
+  );
+}
+```


### PR DESCRIPTION
## Summary
- document common usage examples for each BGUI component
- show a login form example using BGUI pieces
- link to snippets from the docs hub

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851baab73d88320a695eec12fc1c156