### PR TITLE
Add BGUI usage snippets

### DIFF
--- a/docs/snippets/button-usage.tsx
+++ b/docs/snippets/button-usage.tsx
@@ -1,0 +1,11 @@
+import { Button } from "@braingame/bgui";
+
+export const ButtonUsage = () => {
+        const handlePress = () => {
+                console.log("Pressed!");
+        };
+
+        return (
+                <Button onPress={handlePress}>Click me</Button>
+        );
+};

--- a/docs/snippets/errorboundary-usage.tsx
+++ b/docs/snippets/errorboundary-usage.tsx
@@ -1,0 +1,8 @@
+import { ErrorBoundary } from "@braingame/bgui";
+import { Text } from "@braingame/bgui";
+
+export const ErrorBoundaryUsage = () => (
+        <ErrorBoundary>
+                <Text>Safe content</Text>
+        </ErrorBoundary>
+);

--- a/docs/snippets/icon-usage.tsx
+++ b/docs/snippets/icon-usage.tsx
@@ -1,0 +1,5 @@
+import { Icon } from "@braingame/bgui";
+
+export const IconUsage = () => (
+        <Icon name="user" size="secondary" />
+);

--- a/docs/snippets/link-usage.tsx
+++ b/docs/snippets/link-usage.tsx
@@ -1,0 +1,5 @@
+import { Link } from "@braingame/bgui";
+
+export const LinkUsage = () => (
+        <Link href="/about">Go to About</Link>
+);

--- a/docs/snippets/login-form-example.tsx
+++ b/docs/snippets/login-form-example.tsx
@@ -1,0 +1,38 @@
+import { Button, TextInput, View, Text } from "@braingame/bgui";
+import { Checkbox } from "@braingame/bgui"; // planned component
+import { useState } from "react";
+
+export const LoginFormExample = () => {
+        const [email, setEmail] = useState("");
+        const [password, setPassword] = useState("");
+        const [remember, setRemember] = useState(false);
+
+        const handleSubmit = () => {
+                // handle login
+        };
+
+        return (
+                <View style={{ gap: 12 }}>
+                        <TextInput
+                                value={email}
+                                onChangeText={setEmail}
+                                placeholder="Email"
+                        />
+                        <TextInput
+                                value={password}
+                                onChangeText={setPassword}
+                                placeholder="Password"
+                                secureTextEntry
+                        />
+                        <View style={{ flexDirection: "row", alignItems: "center" }}>
+                                <Checkbox
+                                        checked={remember}
+                                        onValueChange={setRemember}
+                                >
+                                        <Text>Remember me</Text>
+                                </Checkbox>
+                        </View>
+                        <Button onPress={handleSubmit}>Log In</Button>
+                </View>
+        );
+};

--- a/docs/snippets/pagewrapper-usage.tsx
+++ b/docs/snippets/pagewrapper-usage.tsx
@@ -1,0 +1,7 @@
+import { PageWrapper, Text } from "@braingame/bgui";
+
+export const PageWrapperUsage = () => (
+        <PageWrapper>
+                <Text>Page Content</Text>
+        </PageWrapper>
+);

--- a/docs/snippets/text-usage.tsx
+++ b/docs/snippets/text-usage.tsx
@@ -1,0 +1,5 @@
+import { Text } from "@braingame/bgui";
+
+export const TextUsage = () => (
+        <Text type="title">Welcome to Brain Game</Text>
+);

--- a/docs/snippets/textinput-usage.tsx
+++ b/docs/snippets/textinput-usage.tsx
@@ -1,0 +1,14 @@
+import { TextInput } from "@braingame/bgui";
+import { useState } from "react";
+
+export const TextInputUsage = () => {
+        const [value, setValue] = useState("");
+
+        return (
+                <TextInput
+                        value={value}
+                        onChangeText={setValue}
+                        placeholder="Enter text"
+                />
+        );
+};

--- a/docs/snippets/view-usage.tsx
+++ b/docs/snippets/view-usage.tsx
@@ -1,0 +1,7 @@
+import { View } from "@braingame/bgui";
+
+export const ViewUsage = () => (
+        <View style={{ padding: 16 }}>
+                {/* content */}
+        </View>
+);


### PR DESCRIPTION
## Summary
- provide usage snippets for BGUI components
- add login form example showing multiple components together

## Testing
- `pnpm lint` *(fails: ENETUNREACH while fetching pnpm)*
- `pnpm test` *(fails: ENETUNREACH while fetching pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6851baad20f88320a8fafc5b63f00e90