### PR TITLE
Add useDisclosure hook

### DIFF
--- a/packages/utils/hooks/index.ts
+++ b/packages/utils/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./useTaskInput";
 export * from "./useThemeColor";
 export * from "./useDraggableTaskHandlers";
 export * from "./useColorScheme";
+export * from "./useDisclosure";

--- a/packages/utils/hooks/useDisclosure.test.ts
+++ b/packages/utils/hooks/useDisclosure.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useDisclosure } from './useDisclosure';
+
+describe('useDisclosure', () => {
+  it('opens and closes correctly', () => {
+    const { result } = renderHook(() => useDisclosure());
+
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('toggles state', () => {
+    const { result } = renderHook(() => useDisclosure());
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('calls onOpenChange callback', () => {
+    const callback = jest.fn();
+    const { result } = renderHook(() => useDisclosure({ onOpenChange: callback }));
+
+    act(() => {
+      result.current.open();
+    });
+    expect(callback).toHaveBeenCalledWith(true);
+
+    act(() => {
+      result.current.close();
+    });
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/utils/hooks/useDisclosure.ts
+++ b/packages/utils/hooks/useDisclosure.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from "react";
+
+export interface UseDisclosureOptions {
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function useDisclosure(options: UseDisclosureOptions = {}) {
+  const { defaultOpen = false, onOpenChange } = options;
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    onOpenChange?.(true);
+  }, [onOpenChange]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    onOpenChange?.(false);
+  }, [onOpenChange]);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      onOpenChange?.(next);
+      return next;
+    });
+  }, [onOpenChange]);
+
+  return { isOpen, open, close, toggle };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useDisclosure` hook with open/close/toggle helpers
- export the new hook from utils package
- test the hook using `@testing-library/react-native`

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685289cfda6883208b92c83add47265b