### PR TITLE
docs: fix outdated turbo filename

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,7 +57,7 @@ braingame/
 ├── .github/workflows/     # CI / CD
 ├── firebase.json
 ├── .firebaserc
-├── turborepo.json
+├── turbo.json
 ├── pnpm-workspace.yaml
 └── package.json
 ```
@@ -79,7 +79,7 @@ braingame/
 | Storybook | `pnpm storybook` (placeholder) |
 | Prod build | `pnpm build` (Turbo graph) |
 
-Turbo pipelines (defined in `turborepo.json`):
+Turbo pipelines (defined in `turbo.json`):
 
 ```
 dev   -> transpile            (no cache)


### PR DESCRIPTION
## Summary
- update `turborepo.json` references to `turbo.json`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*

------
https://chatgpt.com/codex/tasks/task_e_68544fca9fc88320a9ae2b9c9789067a