### PR TITLE
docs: enrich component guides with examples

### DIFF
--- a/docs/components/Button.md
+++ b/docs/components/Button.md
@@ -1,11 +1,37 @@
 # Button
 
+The primary action component. Buttons use `Colors.universal.primary` and spacing
+values from `Tokens` to ensure consistent styling across the app.
+
 | Prop | Type | Default |
 | --- | --- | --- |
-| `text` | `string` | – |
-| `icon` | `string` | – |
-| `iconColor` | `string` | – |
-| `iconType` | `string` | – |
+| `children` | `ReactNode` | required |
 | `onPress` | `() => void` | required |
-| `disabled` | `boolean` | – |
+| `icon?` | `string` | – |
+| `iconPosition?` | `'left' \| 'right'` | `'left'` |
+| `size?` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `fullWidth?` | `boolean` | `false` |
+| `disabled?` | `boolean` | `false` |
+| `loading?` | `boolean` | `false` |
+| `aria-label?` | `string` | – |
+| `aria-describedby?` | `string` | – |
+
+## Usage
+
+```tsx
+import { Button } from '@braingame/bgui';
+import { Tokens } from '@braingame/utils';
+
+export function SaveButton() {
+  return (
+    <Button
+      variant="primary"
+      onPress={() => console.log('save')}
+      style={{ paddingHorizontal: Tokens.xl }}
+    >
+      Save
+    </Button>
+  );
+}
+```
 

--- a/docs/components/ErrorBoundary.md
+++ b/docs/components/ErrorBoundary.md
@@ -1,11 +1,22 @@
 # ErrorBoundary
 
+Catches runtime errors in descendant components and displays a fallback UI. No design tokens are required but it follows the same accessibility practices as the rest of the library.
+
 | Prop | Type | Default |
 | --- | --- | --- |
 | `children` | `ReactNode` | required |
 | `fallback` | `ReactNode` | – |
 | `onError` | `(error: Error, info: ErrorInfo) => void` | – |
-| `resetOnPropsChange` | `boolean` | – |
-| `resetKeys` | `Array<string | number>` | – |
-| `isolate` | `boolean` | – |
+| `resetOnPropsChange?` | `boolean` | – |
+| `resetKeys?` | `Array<string | number>` | – |
+| `isolate?` | `boolean` | – |
 
+## Usage
+
+```tsx
+import { ErrorBoundary } from '@braingame/bgui';
+
+<ErrorBoundary fallback={<Text>Something went wrong</Text>}>
+  <ProfileForm />
+</ErrorBoundary>;
+```

--- a/docs/components/Icon.md
+++ b/docs/components/Icon.md
@@ -1,10 +1,23 @@
 # Icon
 
+Displays a vector icon from the FontAwesome set. Sizes map to `Tokens` values so
+icons scale consistently with text.
+
 | Prop | Type | Default |
 | --- | --- | --- |
 | `name` | `string` | required |
-| `size` | `IconSizeProps \| number` | `"secondary"` |
-| `color` | `string` | theme value |
-| `type` | `string` | `"fas"` |
-| `style` | `StyleProp<ViewStyle>` | – |
+| `size?` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `color?` | `ThemeColor` | theme value |
+| `variant?` | `'solid' \| 'regular' \| 'brand'` | `'regular'` |
+| `decorative?` | `boolean` | `false` |
+| `aria-label?` | `string` | – |
+
+## Usage
+
+```tsx
+import { Icon } from '@braingame/bgui';
+import { Tokens } from '@braingame/utils';
+
+<Icon name="heart" size="lg" color="primary" style={{ margin: Tokens.s }} />;
+```
 

--- a/docs/components/Link.md
+++ b/docs/components/Link.md
@@ -1,9 +1,23 @@
 # Link
 
+Navigation element for internal and external destinations.
+
 | Prop | Type | Default |
 | --- | --- | --- |
-| `href` | `string` | required |
-| `text` | `string` | – |
-| `children` | `ReactNode` | – |
-| `...ExpoLinkProps` | `expo-router LinkProps` | – |
+| `href?` | `string` | – |
+| `onPress?` | `() => void` | – |
+| `external?` | `boolean` | `false` |
+| `disabled?` | `boolean` | `false` |
+| `aria-label?` | `string` | – |
+| `children` | `ReactNode` | required |
+
+## Usage
+
+```tsx
+import { Link } from '@braingame/bgui';
+
+<Link href="/settings" aria-label="settings">
+  Settings
+</Link>;
+```
 

--- a/docs/components/PageWrapper.md
+++ b/docs/components/PageWrapper.md
@@ -1,6 +1,23 @@
 # PageWrapper
 
+Provides consistent page margins and scrolling behavior. Wrap your screens with
+this component rather than using raw `View` elements.
+
 | Prop | Type | Default |
 | --- | --- | --- |
 | `children` | `ReactNode` | required |
+
+## Usage
+
+```tsx
+import { PageWrapper } from '@braingame/bgui';
+
+export default function ProfileScreen() {
+  return (
+    <PageWrapper>
+      {/* page content */}
+    </PageWrapper>
+  );
+}
+```
 

--- a/docs/components/Text.md
+++ b/docs/components/Text.md
@@ -1,7 +1,21 @@
 # Text
 
+Typography primitive that uses the `Typography.fontSize` scale and theme colors.
+
 | Prop | Type | Default |
 | --- | --- | --- |
-| `type` | `"display" | "title" | "subtitle" | "default" | "small" | "link"` | `"default"` |
+| `children` | `ReactNode` | required |
+| `color?` | `ThemeColor` | `text` |
+| `align?` | `'left' \| 'center' \| 'right'` | `'left'` |
+| `numberOfLines?` | `number` | – |
+| `variant` | `'h1' \| 'h2' \| 'h3' \| 'body' \| 'caption'` | `'body'` |
 | `...RNTextProps` | `React Native TextProps` | – |
+
+## Usage
+
+```tsx
+import { Text } from '@braingame/bgui';
+
+<Text variant="h1" color="primary">Welcome</Text>;
+```
 

--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -1,6 +1,33 @@
 # TextInput
 
+Wrapper around React Native's input field. It follows the design token palette
+for borders and text colors: `Colors.text`, `Colors.textSecondary`, and
+`Colors.border`.
+
 | Prop | Type | Default |
 | --- | --- | --- |
-| `...RNTextInputProps` | `React Native TextInputProps` | – |
+| `value` | `string` | required |
+| `onValueChange` | `(value: string) => void` | required |
+| `placeholder?` | `string` | – |
+| `secureTextEntry?` | `boolean` | `false` |
+| `multiline?` | `boolean` | `false` |
+| `autoComplete?` | `string` | – |
+| `maxLength?` | `number` | – |
+| `leftIcon?` | `string` | – |
+| `rightIcon?` | `string` | – |
+| `disabled?` | `boolean` | `false` |
+| `aria-label?` | `string` | – |
+| `aria-describedby?` | `string` | – |
+
+## Usage
+
+```tsx
+import { TextInput } from '@braingame/bgui';
+
+<TextInput
+  value={name}
+  onValueChange={setName}
+  placeholder="Enter your name"
+/>;
+```
 

--- a/docs/components/View.md
+++ b/docs/components/View.md
@@ -1,12 +1,24 @@
 # View
 
+Container element styled with `Colors.background`, `Colors.card`, and spacing
+tokens. Useful for layout primitives on both web and native.
+
 | Prop | Type | Default |
 | --- | --- | --- |
-| `type` | `"background" | "card" | "surface" | "mini-card"` | `"background"` |
-| `transparent` | `boolean` | – |
-| `rounded` | `boolean` | – |
-| `border` | `boolean` | – |
-| `hoverable` | `boolean` | – |
-| `grabbable` | `boolean` | – |
+| `type` | `'background' \| 'card' \| 'surface' \| 'mini-card'` | `'background'` |
+| `transparent?` | `boolean` | – |
+| `rounded?` | `boolean` | – |
+| `border?` | `boolean` | – |
+| `hoverable?` | `boolean` | – |
+| `grabbable?` | `boolean` | – |
 | `...RNViewProps` | `React Native ViewProps` | – |
+
+## Usage
+
+```tsx
+import { View } from '@braingame/bgui';
+import { Colors } from '@braingame/utils';
+
+<View type="card" style={{ backgroundColor: Colors.card }} />;
+```
 


### PR DESCRIPTION
## Summary
- add detailed usage sections for each BGUI component doc
- reference design tokens and update prop tables

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6854d8f97d1c83208649e470b6aed989