### PR TITLE
feat(bgui): add Alert, Breadcrumb and TextInput

### DIFF
--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -23,6 +23,16 @@
 ## 2. Session Summaries
 *All summaries are in reverse chronological order (newest first).*
 
+### 20-06-2025 - Added Alert, Breadcrumb and TextInput Components
+- **Agent**: ChatGPT
+- **Tasks**: Implement missing BGUI components and update documentation
+- **Completed**:
+  - Created `Alert`, `Breadcrumb`, and `TextInput` components with types, styles and tests
+  - Exported new components from `@braingame/bgui`
+  - Added prop documentation for each component
+  - Updated TODO tracker and work session notes
+- **Next Steps**: Review component APIs and expand test coverage
+
 ### 20-06-2025 - Preflight Documentation Update
 - **Agent**: ChatGPT (Codex)
 - **Tasks**: Document requirement to run `pnpm install` before lint or test, add `preflight` script

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -128,6 +128,8 @@
   - [ ] Document props for each BGUI component
   - Status: in_progress (17-06-2025)
 
+- [x] Implement remaining BGUI components (Alert, Breadcrumb, TextInput) - 20-06-2025
+
 - [ ] Environment Management
   - [ ] Create `.env.example` files (in progress)
   - [ ] Add validation with zod

--- a/docs/components/Alert.md
+++ b/docs/components/Alert.md
@@ -1,0 +1,11 @@
+# Alert
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `title` | `string` | – |
+| `message` | `string` | required |
+| `type` | `"info" \| "success" \| "warning" \| "error"` | `"info"` |
+| `actions` | `ReactNode` | – |
+| `dismissible` | `boolean` | `false` |
+| `onDismiss` | `() => void` | – |
+| `variant` | `"banner" \| "inline" \| "floating"` | `"banner"` |

--- a/docs/components/Breadcrumb.md
+++ b/docs/components/Breadcrumb.md
@@ -1,0 +1,8 @@
+# Breadcrumb
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `children` | `ReactNode` | required |
+| `separator` | `ReactNode` | `'/'` |
+| `maxItems` | `number` | – |
+| `variant` | `"standard" \| "compact"` | `"standard"` |

--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -16,8 +16,10 @@ for borders and text colors: `Colors.text`, `Colors.textSecondary`, and
 | `leftIcon?` | `string` | – |
 | `rightIcon?` | `string` | – |
 | `disabled?` | `boolean` | `false` |
+| `variant` | `"standard" \| "flat" \| "error"` | `"standard"` |
 | `aria-label?` | `string` | – |
 | `aria-describedby?` | `string` | – |
+| `...RNTextInputProps` | `React Native TextInputProps` | – |
 
 ## Usage
 
@@ -30,4 +32,3 @@ import { TextInput } from '@braingame/bgui';
   placeholder="Enter your name"
 />;
 ```
-

--- a/docs/work-sessions/2025-06-20-add-alert-breadcrumb-textinput.md
+++ b/docs/work-sessions/2025-06-20-add-alert-breadcrumb-textinput.md
@@ -1,0 +1,21 @@
+# Work Session - 20-06-2025
+
+## Agent
+ChatGPT
+
+## Objectives
+- Implement missing BGUI components
+
+## Tasks Completed
+- Added `Alert`, `Breadcrumb` and `TextInput` components with types, styles and tests
+- Updated package exports and documentation
+- Created prop docs for new components
+- Updated TODO tracker and AI context
+
+## Key Learnings
+- Followed existing component patterns for styling and testing
+- Used theme tokens for consistent design
+
+## Future Work
+- Expand component test coverage
+- Review accessibility for new components

--- a/packages/bgui/index.ts
+++ b/packages/bgui/index.ts
@@ -16,6 +16,8 @@ export { Icon } from "./src/components/Icon";
 export { Image } from "./src/components/Image";
 export { Label } from "./src/components/Label";
 export { Link } from "./src/components/Link";
+export { Alert } from "./src/components/Alert";
+export { Breadcrumb, BreadcrumbItem } from "./src/components/Breadcrumb";
 export { Menu, MenuItem } from "./src/components/Menu";
 export { Modal, ModalFooter, ModalHeader } from "./src/components/Modal";
 export { ProgressBar } from "./src/components/ProgressBar";
@@ -26,12 +28,11 @@ export { Spinner } from "./src/components/Spinner";
 export { Switch } from "./src/components/Switch";
 export { Tabs } from "./src/components/Tabs";
 export { Text } from "./src/components/Text";
+export { TextInput } from "./src/components/TextInput";
 export { Toast } from "./src/components/Toast";
 export { Tooltip } from "./src/components/Tooltip";
 // Core Layout Components
 export { View } from "./View";
-
-// Note: TextInput removed - apps use React Native's built-in TextInput
 
 export type { PageWrapperProps } from "./PageWrapper/types";
 export type { AccordionProps } from "./src/components/Accordion";
@@ -47,6 +48,8 @@ export type { IconProps } from "./src/components/Icon/types";
 export type { ImageProps } from "./src/components/Image/types";
 export type { LabelProps } from "./src/components/Label/types";
 export type { LinkProps } from "./src/components/Link/types";
+export type { AlertProps, AlertType, AlertVariant } from "./src/components/Alert";
+export type { BreadcrumbProps, BreadcrumbItemProps } from "./src/components/Breadcrumb";
 export type { MenuItemProps, MenuProps } from "./src/components/Menu/types";
 export type { ModalProps } from "./src/components/Modal/types";
 export type { ProgressBarProps } from "./src/components/ProgressBar/types";
@@ -57,6 +60,7 @@ export type { SpinnerProps } from "./src/components/Spinner/types";
 export type { SwitchProps } from "./src/components/Switch/types";
 export type { TabProps, TabsPanelProps, TabsProps } from "./src/components/Tabs/types";
 export type { TextProps } from "./src/components/Text/types";
+export type { TextInputProps } from "./src/components/TextInput/types";
 export type { ToastProps } from "./src/components/Toast/types";
 export type { TooltipProps } from "./src/components/Tooltip/types";
 // Constants

--- a/packages/bgui/src/components/Alert/Alert.test.tsx
+++ b/packages/bgui/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, render } from "../../test-utils";
+import React from "react";
+import { Alert } from "./Alert";
+
+describe("Alert", () => {
+	it("renders message and title", () => {
+		const { getByText } = render(<Alert title="Info" message="hello" />);
+		expect(getByText("Info")).toBeTruthy();
+		expect(getByText("hello")).toBeTruthy();
+	});
+
+	it("calls onDismiss when dismiss button pressed", () => {
+		const onDismiss = jest.fn();
+		const { getByLabelText } = render(<Alert message="bye" dismissible onDismiss={onDismiss} />);
+		fireEvent.press(getByLabelText("Dismiss"));
+		expect(onDismiss).toHaveBeenCalled();
+	});
+});

--- a/packages/bgui/src/components/Alert/Alert.tsx
+++ b/packages/bgui/src/components/Alert/Alert.tsx
@@ -1,0 +1,44 @@
+import { useThemeColor } from "@braingame/utils";
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+import { Icon } from "../Icon";
+import { styles, typeColorMap } from "./styles";
+import type { AlertProps } from "./types";
+
+export function Alert({
+	title,
+	message,
+	type = "info",
+	actions,
+	dismissible = false,
+	onDismiss,
+	variant = "banner",
+	style,
+}: AlertProps) {
+	const textColor = useThemeColor("text");
+	const backgroundColor = typeColorMap[type];
+
+	return (
+		<View
+			accessibilityRole="alert"
+			style={[
+				styles.container,
+				{ backgroundColor },
+				variant === "inline" && { borderRadius: 0 },
+				variant === "floating" && { elevation: 4 },
+				style,
+			]}
+		>
+			<View style={styles.content}>
+				{title ? <Text style={[styles.title, { color: textColor }]}>{title}</Text> : null}
+				<Text style={{ color: textColor }}>{message}</Text>
+			</View>
+			{actions && <View style={styles.actions}>{actions}</View>}
+			{dismissible && (
+				<Pressable accessibilityLabel="Dismiss" onPress={onDismiss}>
+					<Icon name="xmark" size={16} color={textColor} />
+				</Pressable>
+			)}
+		</View>
+	);
+}

--- a/packages/bgui/src/components/Alert/index.ts
+++ b/packages/bgui/src/components/Alert/index.ts
@@ -1,0 +1,2 @@
+export { Alert } from "./Alert";
+export type { AlertProps, AlertType, AlertVariant } from "./types";

--- a/packages/bgui/src/components/Alert/styles.ts
+++ b/packages/bgui/src/components/Alert/styles.ts
@@ -1,0 +1,25 @@
+import { Colors, Tokens } from "@braingame/utils";
+import { StyleSheet } from "react-native";
+import type { AlertType } from "./types";
+
+export const typeColorMap: Record<AlertType, string> = {
+	info: Colors.universal.primaryFaded,
+	success: Colors.universal.positiveFaded,
+	warning: Colors.universal.warnFaded,
+	error: Colors.universal.negativeFaded,
+};
+
+export const styles = StyleSheet.create({
+	container: {
+		width: "100%",
+		paddingVertical: Tokens.s,
+		paddingHorizontal: Tokens.m,
+		borderRadius: Tokens.s,
+		flexDirection: "row",
+		alignItems: "flex-start",
+		gap: Tokens.s,
+	},
+	content: { flex: 1 },
+	title: { fontWeight: "600", marginBottom: Tokens.xs },
+	actions: { marginLeft: Tokens.s },
+});

--- a/packages/bgui/src/components/Alert/types.ts
+++ b/packages/bgui/src/components/Alert/types.ts
@@ -1,0 +1,20 @@
+export type AlertType = "info" | "success" | "warning" | "error";
+export type AlertVariant = "banner" | "inline" | "floating";
+
+export interface AlertProps {
+	/** Optional title displayed above the message */
+	title?: string;
+	/** Main alert message */
+	message: string;
+	/** Visual type controlling background color */
+	type?: AlertType;
+	/** Optional actions rendered to the right */
+	actions?: React.ReactNode;
+	/** Whether the alert can be dismissed */
+	dismissible?: boolean;
+	/** Callback when the alert is dismissed */
+	onDismiss?: () => void;
+	/** Visual presentation variant */
+	variant?: AlertVariant;
+	style?: any;
+}

--- a/packages/bgui/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/bgui/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render } from "../../test-utils";
+import { Breadcrumb, BreadcrumbItem } from "./Breadcrumb";
+
+describe("Breadcrumb", () => {
+	it("renders items with separators", () => {
+		const { getByText } = render(
+			<Breadcrumb>
+				<BreadcrumbItem href="/">Home</BreadcrumbItem>
+				<BreadcrumbItem>Library</BreadcrumbItem>
+			</Breadcrumb>,
+		);
+		expect(getByText("Home")).toBeTruthy();
+		expect(getByText("Library")).toBeTruthy();
+	});
+
+	it("collapses items when maxItems exceeded", () => {
+		const { getByText } = render(
+			<Breadcrumb maxItems={2}>
+				<BreadcrumbItem href="/">Home</BreadcrumbItem>
+				<BreadcrumbItem href="/cat">Cat</BreadcrumbItem>
+				<BreadcrumbItem>Page</BreadcrumbItem>
+			</Breadcrumb>,
+		);
+		expect(getByText("...")).toBeTruthy();
+		expect(getByText("Page")).toBeTruthy();
+	});
+});

--- a/packages/bgui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/bgui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { Link } from "../Link";
+import { styles } from "./styles";
+import type { BreadcrumbItemProps, BreadcrumbProps } from "./types";
+
+export function BreadcrumbItem({ children, href }: BreadcrumbItemProps) {
+	return href ? <Link href={href}>{children}</Link> : <Text>{children}</Text>;
+}
+
+export function Breadcrumb({
+	children,
+	separator = "/",
+	maxItems,
+	variant = "standard",
+	style,
+}: BreadcrumbProps) {
+	const items = React.Children.toArray(children);
+	let displayItems = items;
+	if (maxItems && items.length > maxItems) {
+		displayItems = [items[0], "...", items[items.length - 1]];
+	}
+
+	return (
+		<View accessibilityRole="navigation" style={[styles.container, style]}>
+			{displayItems.map((child, index) => (
+				<View key={index} style={[styles.item, variant === "compact" && styles.compactItem]}>
+					{child}
+					{index < displayItems.length - 1 && <Text>{separator}</Text>}
+				</View>
+			))}
+		</View>
+	);
+}

--- a/packages/bgui/src/components/Breadcrumb/index.ts
+++ b/packages/bgui/src/components/Breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export { Breadcrumb, BreadcrumbItem } from "./Breadcrumb";
+export type { BreadcrumbProps, BreadcrumbItemProps } from "./types";

--- a/packages/bgui/src/components/Breadcrumb/styles.ts
+++ b/packages/bgui/src/components/Breadcrumb/styles.ts
@@ -1,0 +1,18 @@
+import { Tokens } from "@braingame/utils";
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+	container: {
+		flexDirection: "row",
+		alignItems: "center",
+		flexWrap: "wrap",
+	},
+	item: {
+		marginRight: Tokens.xs,
+		flexDirection: "row",
+		alignItems: "center",
+	},
+	compactItem: {
+		marginRight: Tokens.xxs,
+	},
+});

--- a/packages/bgui/src/components/Breadcrumb/types.ts
+++ b/packages/bgui/src/components/Breadcrumb/types.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export interface BreadcrumbItemProps {
+	children: ReactNode;
+	href?: string;
+}
+
+export interface BreadcrumbProps {
+	children: ReactNode;
+	separator?: ReactNode;
+	maxItems?: number;
+	variant?: "standard" | "compact";
+	style?: any;
+}

--- a/packages/bgui/src/components/TextInput/TextInput.test.tsx
+++ b/packages/bgui/src/components/TextInput/TextInput.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { fireEvent, render } from "../../test-utils";
+import { TextInput } from "./TextInput";
+
+describe("TextInput", () => {
+	it("calls onValueChange", () => {
+		const onChange = jest.fn();
+		const { getByDisplayValue } = render(<TextInput value="hi" onValueChange={onChange} />);
+		const input = getByDisplayValue("hi");
+		fireEvent.changeText(input, "bye");
+		expect(onChange).toHaveBeenCalledWith("bye");
+	});
+
+	it("renders icons", () => {
+		const { getAllByRole } = render(
+			<TextInput value="" onValueChange={() => {}} leftIcon="user" rightIcon="x" />,
+		);
+		expect(getAllByRole("image").length).toBe(2);
+	});
+});

--- a/packages/bgui/src/components/TextInput/TextInput.tsx
+++ b/packages/bgui/src/components/TextInput/TextInput.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { TextInput as RNTextInput, View } from "react-native";
+import { Icon } from "../Icon";
+import { styles } from "./styles";
+import type { TextInputProps } from "./types";
+
+export function TextInput({
+	value,
+	onValueChange,
+	leftIcon,
+	rightIcon,
+	variant = "standard",
+	style,
+	...rest
+}: TextInputProps) {
+	return (
+		<View
+			style={[
+				styles.container,
+				variant === "flat" && styles.flat,
+				variant === "error" && styles.error,
+				style,
+			]}
+		>
+			{leftIcon && <Icon name={leftIcon} style={styles.icon} />}
+			<RNTextInput style={styles.input} value={value} onChangeText={onValueChange} {...rest} />
+			{rightIcon && <Icon name={rightIcon} style={styles.icon} />}
+		</View>
+	);
+}

--- a/packages/bgui/src/components/TextInput/index.ts
+++ b/packages/bgui/src/components/TextInput/index.ts
@@ -1,0 +1,2 @@
+export { TextInput } from "./TextInput";
+export type { TextInputProps } from "./types";

--- a/packages/bgui/src/components/TextInput/styles.ts
+++ b/packages/bgui/src/components/TextInput/styles.ts
@@ -1,0 +1,27 @@
+import { Colors, Tokens } from "@braingame/utils";
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+	container: {
+		flexDirection: "row",
+		alignItems: "center",
+		borderWidth: 1,
+		borderColor: Colors.light.border,
+		paddingHorizontal: Tokens.s,
+		borderRadius: Tokens.s,
+	},
+	flat: {
+		borderWidth: 0,
+		borderBottomWidth: 1,
+	},
+	error: {
+		borderColor: Colors.universal.negative,
+	},
+	input: {
+		flex: 1,
+		paddingVertical: Tokens.xs,
+	},
+	icon: {
+		marginHorizontal: Tokens.xs,
+	},
+});

--- a/packages/bgui/src/components/TextInput/types.ts
+++ b/packages/bgui/src/components/TextInput/types.ts
@@ -1,0 +1,14 @@
+import type { TextInputProps as RNTextInputProps } from "react-native";
+
+export interface TextInputProps extends RNTextInputProps {
+	/** Current value */
+	value: string;
+	/** Callback when value changes */
+	onValueChange: (value: string) => void;
+	/** Left icon name */
+	leftIcon?: string;
+	/** Right icon name */
+	rightIcon?: string;
+	/** Visual variant */
+	variant?: "standard" | "flat" | "error";
+}


### PR DESCRIPTION
## Summary
- add Alert component with dismiss action
- add Breadcrumb component and item helper
- add customizable TextInput component
- export new components from BGUI
- document new components and update TODO/AI context
- record development session notes

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6854d8fa5f8c832096bd17071d75284d