### PR TITLE
docs: add component organization guide

### DIFF
--- a/docs/COMPONENT_ORGANIZATION.md
+++ b/docs/COMPONENT_ORGANIZATION.md
@@ -1,0 +1,50 @@
+# Component Organization Guide
+
+This guide explains how we structure folders in the Brain Game monorepo and the conventions we follow when naming files.
+
+## Monorepo Layout
+
+The high level directory layout is defined in [ARCHITECTURE.md](./ARCHITECTURE.md). At a glance:
+
+```text
+braingame/
+├─ apps/        # Deployable Expo/Next applications
+├─ packages/    # Reusable libraries (UI kit, utilities, config)
+└─ docs/        # Documentation and design notes
+```
+
+Applications may depend on any package, but packages should never import from apps.
+
+## BGUI Component Structure
+
+All reusable UI components live in `packages/bgui/src/components`. Each component has its own folder named with **PascalCase**:
+
+```
+packages/bgui/src/components/ExampleComponent/
+├─ ExampleComponent.tsx
+├─ styles.ts
+├─ types.ts
+├─ utils.ts
+├─ ExampleComponent.test.tsx
+└─ index.ts        # `export * from './ExampleComponent'`
+```
+
+Simple components can be a single file, but once additional styles, utilities or tests are required the folder-per-component pattern above should be used. This keeps logic, tests and types colocated.
+
+## Naming Conventions
+
+Naming rules mirror those in [CODING_STYLE.md](./CODING_STYLE.md):
+
+| Item | Convention |
+|------|------------|
+| Components & Types | `PascalCase` |
+| Files & Directories | `kebab-case` for general folders, but BGUI component folders use `PascalCase` |
+| Variables & Functions | `camelCase` |
+| Constants | `CONSTANT_CASE` |
+| Custom Hooks | `useCamelCase` |
+
+Custom hooks shared across packages belong in `packages/utils/src/hooks` and should be prefixed with `use`.
+
+---
+
+Following these standards helps every contributor understand where code lives and keeps imports predictable.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 | [`CODING_STYLE.md`](./CODING_STYLE.md) | The definitive guide to writing clean, maintainable code in this repository. |
 | [`BRAND.md`](./BRAND.md) | The official brand book defining our voice, tone, and brand assets. |
 | [`BGUI_COMPONENT_PLAN.md`](./BGUI_COMPONENT_PLAN.md) | The detailed API and specification for our BGUI component library. |
+| [`COMPONENT_ORGANIZATION.md`](./COMPONENT_ORGANIZATION.md) | Folder structure and naming conventions. |
 | [`SECURITY.md`](../.github/SECURITY.md) | Our security policy, including how to report vulnerabilities. |
 
 ## 📚 Component Snippets

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -147,7 +147,7 @@ Systematic improvement of all BGUI components to ensure premium quality standard
 - [x] Fix index file extensions across all components
 - [x] Standardize exports (removed default exports from Accordion, Tooltip)
 - [x] Extract inline styles to dedicated styles.ts files for all components
-- [ ] Document component organization standards
+- [x] Document component organization standards (20-06-2025)
 
 ### Phase 8: Fix Styling Issues ✅ COMPLETED (19-06-2025)
 - [x] Replace hardcoded values with theme tokens


### PR DESCRIPTION
## Summary
- add a COMPONENT_ORGANIZATION guide explaining folder layout and naming
- link the new document in the docs index
- mark TODO item for documenting component organization as done

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6854d8fda7d883209965706cfa8a095d