### PR TITLE
Fix README and docs security links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A key part of our workflow is our task management system. See what we're working
 
 ## 🛡️ Security
 
-Security is a top priority. Please see our **[Security Policy](./SECURITY.md)** for details on our supported versions and how to report vulnerabilities.
+Security is a top priority. Please see our **[Security Policy](.github/SECURITY.md)** for details on our supported versions and how to report vulnerabilities.
 
 ## 📄 License
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -286,7 +286,7 @@ When using AI assistants (like Claude):
 - **Documentation**: Check `/docs` folder
 - **Architecture**: See `docs/ARCHITECTURE.md`
 - **Task Tracking**: See `TODO.md`
-- **Security**: See `SECURITY.md`
+- **Security**: See `../.github/SECURITY.md`
 
 ## VS Code Extensions
 


### PR DESCRIPTION
## Summary
- update README security link to reference `.github/SECURITY.md`
- update DEVELOPMENT guide to link to `../.github/SECURITY.md`

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68550521e2e883209a9c964bbaaf77a5