### PR TITLE
Fix pre-commit to use pnpm test

### DIFF
--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -23,6 +23,20 @@
 ## 2. Session Summaries
 *All summaries are in reverse chronological order (newest first).*
 
+### 20-06-2025 - Husky Pre-commit Hook Update
+- **Agent**: ChatGPT (GPT-4)
+- **Tasks**: Updated utils package pre-commit hook to run `pnpm test` for consistency.
+- **Outcome**: Pre-commit now leverages pnpm workspace scripts.
+
+### 20-06-2025 - BGUI Coverage Improvements
+- **Agent**: ChatGPT
+- **Tasks**: Add Jest tests for PageWrapper and View components and configure coverage reporting
+- **Completed**:
+  - Created `PageWrapper.test.tsx` and `View.test.tsx`
+  - Updated Jest config to include root components
+  - Attempted to run coverage via Jest (tests failing due to React Native dependencies)
+- **Next Steps**: Investigate React Native Jest compatibility to enable full test suite
+
 ### 20-06-2025 - Added Alert, Breadcrumb and TextInput Components
 - **Agent**: ChatGPT
 - **Tasks**: Implement missing BGUI components and update documentation
@@ -32,6 +46,16 @@
   - Added prop documentation for each component
   - Updated TODO tracker and work session notes
 - **Next Steps**: Review component APIs and expand test coverage
+
+### 20-06-2025 - Storybook Setup for BGUI
+- **Agent**: ChatGPT
+- **Tasks**: Configure Storybook and update documentation
+- **Completed**:
+  - Added `.storybook` with `main.ts` and `preview.ts` in `packages/bgui`
+  - Replaced placeholder script with `storybook dev` command
+  - Documented Storybook usage in `DEVELOPMENT.md` and `ARCHITECTURE.md`
+  - Updated TODO to mark Storybook setup complete
+- **Next Steps**: Write component stories and enable visual testing
 
 ### 20-06-2025 - Preflight Documentation Update
 - **Agent**: ChatGPT (Codex)

--- a/docs/work-sessions/2025-06-20-husky-consistency.md
+++ b/docs/work-sessions/2025-06-20-husky-consistency.md
@@ -1,0 +1,23 @@
+# Work Session: Husky Pre-commit Consistency
+
+## Session Metadata
+- **Date**: 20-06-2025
+- **Agent**: ChatGPT (GPT-4)
+- **Duration**: Short
+- **Objectives**: Ensure the utils package uses `pnpm test` in its pre-commit hook.
+
+## Work Completed
+### Task 1: Update Pre-commit Hook
+- Modified `packages/utils/.husky/pre-commit` to run `pnpm test`.
+- Commands run:
+  ```bash
+  apply_patch
+  pnpm lint
+  pnpm test
+  ```
+
+## Key Learnings
+- All packages should use `pnpm` for scripts to leverage workspace resolution.
+
+## Next Steps
+- Validate that tests run once network restrictions are resolved.

--- a/packages/utils/.husky/pre-commit
+++ b/packages/utils/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm test
+pnpm test


### PR DESCRIPTION
## Summary
- update utils pre-commit hook to run `pnpm test`
- document the change in AI context
- add session notes for the work

## Testing
- `pnpm lint` *(fails: ENETUNREACH registry.npmjs.org)*
- `pnpm test` *(fails: ENETUNREACH registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68550525e7fc8320a27000138d1e43d2