### PR TITLE
docs: add preflight instructions for lint/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This monorepo contains the code for all Brain Game applications, websites, and s
 
 To get a local copy up and running, follow our comprehensive **[Development Guide](./docs/DEVELOPMENT.md)**. It contains everything you need for setup, from prerequisites to running the apps.
 
+Before running any lint or test commands, make sure your dependencies are installed:
+
+```bash
+pnpm install    # or pnpm run preflight
+```
+
 For complete documentation including architecture, coding standards, and contribution guides, visit our **[Documentation Hub](./docs/README.md)**.
 
 ---

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -23,6 +23,17 @@
 ## 2. Session Summaries
 *All summaries are in reverse chronological order (newest first).*
 
+### 20-06-2025 - Preflight Documentation Update
+- **Agent**: ChatGPT (Codex)
+- **Tasks**: Document requirement to run `pnpm install` before lint or test, add `preflight` script
+- **Completed**:
+  - Updated `docs/DEVELOPMENT.md` with dependency note
+  - Added preflight instructions to `README.md`
+  - Introduced `preflight` script in `package.json`
+  - Marked task complete in `docs/TODO.md`
+  - Created work session document
+- **Next Steps**: Consider automating additional environment checks
+
 ### 20-06-2025 - Legacy Migration Completion & PR Merging Marathon
 - **Agent**: Claude (Opus 4)
 - **Tasks**: Merge all 7 pending PRs and complete the 4-week legacy migration

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,6 +33,10 @@ Follow these steps exactly to ensure a clean setup.
   pnpm install
   ```
 
+> **Important**: The lint (`pnpm lint`) and test (`pnpm test`) scripts require
+> all dependencies to be installed. Run `pnpm install` first whenever you clone
+> or pull new changes, otherwise these tasks may fail.
+
 - [ ] **3. Set Up Environment Variables:**
   - [ ] Copy the example env files. They are git-ignored.
     ```bash

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -140,6 +140,11 @@
   - [ ] Configure performance monitoring
   - Status: Not started
 
+- [x] Preflight Docs
+  - [x] Clarify that lint and test require `pnpm install`
+  - [x] Add optional `preflight` script
+  - Status: Completed @ 20-06-2025
+
 - [x] Refactor BGUI Button component for readability, performance, and a11y
   - Status: Completed @ 17-06-2025
 

--- a/docs/work-sessions/2025-06-20-preflight-doc-update.md
+++ b/docs/work-sessions/2025-06-20-preflight-doc-update.md
@@ -1,0 +1,19 @@
+# Work Session: Preflight Documentation Update
+
+**Date**: 20-06-2025
+**Agent**: ChatGPT (Codex)
+**Duration**: ~30 minutes
+**Objectives**: Clarify dependency setup for lint and test commands.
+
+## Work Completed
+- Updated `docs/DEVELOPMENT.md` with a note about running `pnpm install` before lint or test.
+- Added a preflight section to `README.md`.
+- Introduced a `preflight` script in `package.json`.
+- Marked the documentation task complete in `docs/TODO.md`.
+
+## Key Learnings
+- New contributors often skip `pnpm install`, leading to failing lint or test runs.
+- A simple script and prominent docs help avoid this confusion.
+
+## Future Recommendations
+- Expand the preflight script to verify Node version and environment variables.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"secrets:scan": "secretlint .",
 		"secrets:check": "secretlint --no-color .",
 		"quality": "turbo lint typecheck test",
+		"preflight": "pnpm install",
 		"ci": "pnpm install --frozen-lockfile && pnpm secrets:check && pnpm quality && pnpm build",
 		"precommit": "lint-staged && pnpm secrets:check && pnpm quality",
 		"storybook": "echo 'Storybook is not yet implemented'",
@@ -66,6 +67,9 @@
 		"pnpm": ">=9"
 	},
 	"lint-staged": {
-		"**/*.{ts,tsx,js,jsx}": ["biome check --fix", "biome format --write"]
+		"**/*.{ts,tsx,js,jsx}": [
+			"biome check --fix",
+			"biome format --write"
+		]
 	}
 }


### PR DESCRIPTION
## Summary
- clarify that lint/test require `pnpm install`
- add optional `preflight` script
- document changes in AI_CONTEXT
- mark TODO item complete
- add work session notes

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68559f0cb7d483209337221c1f359319