### PR TITLE
Improve design token usage

### DIFF
--- a/docs/work-sessions/2025-06-21-design-token-refinements.md
+++ b/docs/work-sessions/2025-06-21-design-token-refinements.md
@@ -1,0 +1,21 @@
+# Work Session: Design token refinements
+
+## Session Metadata
+- **Date**: 21-06-2025
+- **Agent**: Codex (GPT-4)
+- **Objectives**: Apply typed design tokens and replace hardcoded values
+
+## Work Completed
+- Added `as const` to Colors, Tokens, Opacity, and Shadows for literal type inference
+- Exported new union types: `ThemeColor`, `TokenKey`, `OpacityKey`, `ShadowLevel`
+- Replaced hardcoded font sizes in ModalHeader, Select helper text, and Image error text with `Typography` tokens
+- Updated modal width values to use calculations based on spacing tokens
+- Documented session per repository guidelines
+
+## Key Learnings
+- Multiplied spacing tokens can express larger fixed dimensions
+- Centralizing token types improves type safety across components
+
+## Future Recommendations
+- Continue auditing components for direct values
+- Consider exposing layout tokens for common widths

--- a/packages/bgui/src/components/Image/Image.tsx
+++ b/packages/bgui/src/components/Image/Image.tsx
@@ -1,4 +1,4 @@
-import { useThemeColor } from "@braingame/utils";
+import { Typography, useThemeColor } from "@braingame/utils";
 import { useState } from "react";
 import { Image as RNImage, StyleSheet, Text, View } from "react-native";
 import { validateProps, validators } from "../../utils/validation";
@@ -50,7 +50,9 @@ const ImageComponent = ({
 				accessibilityRole="image"
 				accessibilityLabel={`Failed to load image: ${alt}`}
 			>
-				<Text style={{ color: borderColor, fontSize: 12 }}>Failed to load image</Text>
+				<Text style={{ color: borderColor, fontSize: Typography.fontSize.xs }}>
+					Failed to load image
+				</Text>
 			</View>
 		);
 	}

--- a/packages/bgui/src/components/Modal/Modal.tsx
+++ b/packages/bgui/src/components/Modal/Modal.tsx
@@ -106,9 +106,9 @@ const useFocusTrap = (active: boolean, ref: React.RefObject<View | null>, onClos
 };
 
 const sizes = StyleSheet.create({
-	sm: { width: 300 }, // Keep for responsiveness
-	md: { width: 480 }, // Keep for responsiveness
-	lg: { width: 720 }, // Keep for responsiveness
+	sm: { width: Tokens.l * 15 },
+	md: { width: Tokens.xl * 20 },
+	lg: { width: Tokens.xxxxl * 10 },
 	fullscreen: { flex: 1, width: "100%" },
 });
 

--- a/packages/bgui/src/components/Modal/ModalHeader.tsx
+++ b/packages/bgui/src/components/Modal/ModalHeader.tsx
@@ -1,4 +1,4 @@
-import { Tokens, useThemeColor } from "@braingame/utils";
+import { Tokens, Typography, useThemeColor } from "@braingame/utils";
 import type { ReactNode } from "react";
 import { Pressable, Text, View } from "react-native";
 import { Icon } from "../Icon";
@@ -24,7 +24,7 @@ export const ModalHeader = ({ children, closable = true, onClose }: ModalHeaderP
 				marginBottom: Tokens.m,
 			}}
 		>
-			<Text style={{ fontSize: 18, fontWeight: "600" }}>{children}</Text>
+			<Text style={{ fontSize: Typography.fontSize.lg, fontWeight: "600" }}>{children}</Text>
 			{closable && onClose && (
 				<Pressable
 					onPress={onClose}

--- a/packages/bgui/src/components/Select/Select.tsx
+++ b/packages/bgui/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { Colors, Tokens, useThemeColor } from "@braingame/utils";
+import { Colors, Tokens, Typography, useThemeColor } from "@braingame/utils";
 import { Children, cloneElement, type ReactElement, useState } from "react";
 import { Platform, Pressable, Modal as RNModal, ScrollView, View } from "react-native";
 import { Text } from "../../../Text";
@@ -127,10 +127,15 @@ const SelectComponent = ({
 				<Text style={{ color: textColor }}>{label}</Text>
 			</Pressable>
 			{helperText && !error && (
-				<Text style={{ fontSize: 12, color: textColor, marginTop: 4 }}>{helperText}</Text>
+				<Text style={{ fontSize: Typography.fontSize.xs, color: textColor, marginTop: 4 }}>
+					{helperText}
+				</Text>
 			)}
 			{error && errorMessage && (
-				<Text style={{ fontSize: 12, color: errorColor, marginTop: 4 }} accessibilityRole="alert">
+				<Text
+					style={{ fontSize: Typography.fontSize.xs, color: errorColor, marginTop: 4 }}
+					accessibilityRole="alert"
+				>
 					{errorMessage}
 				</Text>
 			)}

--- a/packages/utils/constants/Colors.ts
+++ b/packages/utils/constants/Colors.ts
@@ -42,4 +42,6 @@ export const Colors = {
 		negativeHalfFaded: "rgba(240, 97, 109, .4)",
 		negativeFaded: "rgba(240, 97, 109, .2)",
 	},
-};
+} as const;
+
+export type ThemeColor = keyof typeof Colors.light & keyof typeof Colors.dark;

--- a/packages/utils/constants/Shadows.ts
+++ b/packages/utils/constants/Shadows.ts
@@ -60,4 +60,6 @@ export const Shadows = {
 		shadowOpacity: 0.22,
 		shadowRadius: 16,
 	} as ViewStyle,
-};
+} as const;
+
+export type ShadowLevel = keyof typeof Shadows;

--- a/packages/utils/constants/Tokens.ts
+++ b/packages/utils/constants/Tokens.ts
@@ -13,7 +13,7 @@ export const Tokens = {
 	xxl: 32, // 2rem
 	xxxl: 48, // 3rem
 	xxxxl: 72, // 4.5rem
-};
+} as const;
 
 /**
  * Consistent opacity values for UI states
@@ -24,4 +24,7 @@ export const Opacity = {
 	pressed: 0.8,
 	shadow: 0.1,
 	overlay: 0.7,
-};
+} as const;
+
+export type TokenKey = keyof typeof Tokens;
+export type OpacityKey = keyof typeof Opacity;


### PR DESCRIPTION
## Summary
- refine design token typing
- use typography tokens in Select and Modal components
- calculate modal sizes with Tokens
- adjust Image error text sizing
- document work session

## Testing
- `pnpm lint` *(fails: network access for pnpm)*
- `pnpm test` *(fails: network access for pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68544e2709a88320a5dd3d6e83e63ee0