### PR TITLE
fix: improve TypeScript type safety across components

### DIFF
--- a/packages/bgui/src/components/Alert/types.ts
+++ b/packages/bgui/src/components/Alert/types.ts
@@ -1,3 +1,5 @@
+import type { ViewStyle } from "react-native";
+
 export type AlertType = "info" | "success" | "warning" | "error";
 export type AlertVariant = "banner" | "inline" | "floating";
 
@@ -16,5 +18,5 @@ export interface AlertProps {
 	onDismiss?: () => void;
 	/** Visual presentation variant */
 	variant?: AlertVariant;
-	style?: any;
+	style?: ViewStyle;
 }

--- a/packages/bgui/src/components/Breadcrumb/types.ts
+++ b/packages/bgui/src/components/Breadcrumb/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ViewStyle } from "react-native";
 
 export interface BreadcrumbItemProps {
 	children: ReactNode;
@@ -10,5 +11,5 @@ export interface BreadcrumbProps {
 	separator?: ReactNode;
 	maxItems?: number;
 	variant?: "standard" | "compact";
-	style?: any;
+	style?: ViewStyle;
 }

--- a/packages/bgui/src/components/Link/Link.tsx
+++ b/packages/bgui/src/components/Link/Link.tsx
@@ -36,7 +36,7 @@ export const Link = ({
 	if (href && !external && Platform.OS === "web") {
 		return (
 			<ExpoLink href={href} aria-label={label} style={style} {...rest}>
-				{children as any}
+				{children}
 			</ExpoLink>
 		);
 	}
@@ -48,7 +48,7 @@ export const Link = ({
 			onPress={handlePress}
 			disabled={disabled}
 			style={style}
-			{...(rest as any)}
+			{...rest}
 		>
 			{text}
 		</Pressable>

--- a/packages/bgui/src/components/Link/types.ts
+++ b/packages/bgui/src/components/Link/types.ts
@@ -1,6 +1,8 @@
 import type React from "react";
+import type { PressableProps, ViewStyle } from "react-native";
 
-export interface LinkProps {
+export interface LinkProps
+	extends Omit<PressableProps, "children" | "onPress" | "disabled" | "style"> {
 	children: React.ReactNode;
 	href?: string;
 	onPress?: () => void;
@@ -8,5 +10,5 @@ export interface LinkProps {
 	disabled?: boolean;
 	variant?: "inline" | "standalone";
 	"aria-label"?: string;
-	style?: any;
+	style?: ViewStyle;
 }

--- a/packages/bgui/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/bgui/src/components/ProgressBar/ProgressBar.tsx
@@ -5,7 +5,7 @@ import Svg, { Circle } from "react-native-svg";
 import { getCircularProgressProps, styles } from "./styles";
 import type { ProgressBarProps } from "./types";
 
-const AnimatedCircle = Animated.createAnimatedComponent(Circle as any);
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 export const ProgressBar = ({
 	value,

--- a/packages/bgui/src/utils/validation.ts
+++ b/packages/bgui/src/utils/validation.ts
@@ -111,10 +111,10 @@ export function validateProps<T extends Record<string, any>>(
 	>,
 	componentName: string,
 ) {
-	for (const [propName, validator] of Object.entries(validationRules)) {
+	for (const propName in validationRules) {
+		const validator = validationRules[propName];
 		if (validator && props[propName] !== undefined) {
-			// biome-ignore lint/suspicious/noExplicitAny: Type assertion needed for validator call
-			(validator as any)(props[propName], propName, componentName);
+			validator(props[propName], propName, componentName);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
• Replace `style?: any` with `style?: ViewStyle` in Alert, Breadcrumb, and Link components
• Remove unnecessary `as any` type assertions from ProgressBar and Link components  
• Extend LinkProps with proper PressableProps for better type inference
• Improve validation.ts iterator to avoid type assertion

## Test plan
- [x] Verify no functional changes to components
- [x] Check that proper types are enforced at compile time
- [x] Ensure better IDE support and autocomplete

This PR focuses specifically on replacing explicit `any` types with proper TypeScript types. All changes preserve existing functionality while providing better compile-time safety and IDE support.

Companion to PR #102 which handled lint fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)