### PR TITLE
fix: replace 'any' types with 'unknown' for better type safety

### DIFF
--- a/TypeScriptImprovementsSummary.md
+++ b/TypeScriptImprovementsSummary.md
@@ -1,0 +1,40 @@
+# TypeScript Type Improvements Summary
+
+## Overview
+Improved TypeScript type safety by replacing `any` types with `unknown` in the validation utility.
+
+## Changes Made
+
+### File: `/packages/bgui/src/utils/validation.ts`
+
+1. **Replaced `any` with `unknown`** in all validator functions:
+   - `required`, `number`, `string`, `nonEmptyString`, `boolean`, `function`, `array`, `nonEmptyArray`
+   - Changed from `(value: any, ...)` to `(value: unknown, ...)`
+
+2. **Updated generic constraints**:
+   - Changed `Record<string, any>` to `Record<string, unknown>`
+   - Updated validator function signature to use `unknown`
+
+3. **Added type safety checks**:
+   - Added type guards where needed (e.g., `typeof value === "string"`, `Array.isArray(value)`)
+   - Used type assertion for `oneOf` validator: `value as T`
+
+4. **Introduced type alias** for better readability:
+   ```typescript
+   type Validator = (value: unknown, propName: string, componentName: string) => void;
+   ```
+
+## Results
+
+- **Before**: 10 occurrences of `any` type
+- **After**: 0 occurrences of `any` type
+- All type checks pass successfully
+- No breaking changes to existing code
+- Better type safety without sacrificing functionality
+
+## Benefits
+
+1. **Improved Type Safety**: Using `unknown` forces proper type checking before using values
+2. **Better Developer Experience**: TypeScript will now catch more potential errors at compile time
+3. **Maintained Flexibility**: Validators can still accept any type of value, but must check types before use
+4. **No Runtime Impact**: Changes are purely for type safety, no runtime behavior changes

--- a/packages/bgui/src/utils/validation.ts
+++ b/packages/bgui/src/utils/validation.ts
@@ -23,8 +23,7 @@ export const validators = {
 	 * Validates that a prop value is not null or undefined.
 	 * @throws {PropValidationError} If value is null or undefined
 	 */
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	required: (value: any, propName: string, componentName: string) => {
+	required: (value: unknown, propName: string, componentName: string) => {
 		if (value == null) {
 			throw new PropValidationError(componentName, propName, "This prop is required");
 		}
@@ -32,8 +31,8 @@ export const validators = {
 
 	oneOf:
 		<T>(allowedValues: readonly T[]) =>
-		(value: T, propName: string, componentName: string) => {
-			if (!allowedValues.includes(value)) {
+		(value: unknown, propName: string, componentName: string) => {
+			if (!allowedValues.includes(value as T)) {
 				throw new PropValidationError(
 					componentName,
 					propName,
@@ -42,8 +41,7 @@ export const validators = {
 			}
 		},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	number: (value: any, propName: string, componentName: string) => {
+	number: (value: unknown, propName: string, componentName: string) => {
 		if (typeof value !== "number" || Number.isNaN(value)) {
 			throw new PropValidationError(componentName, propName, "Must be a valid number");
 		}
@@ -57,58 +55,50 @@ export const validators = {
 			}
 		},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	string: (value: any, propName: string, componentName: string) => {
+	string: (value: unknown, propName: string, componentName: string) => {
 		if (typeof value !== "string") {
 			throw new PropValidationError(componentName, propName, "Must be a string");
 		}
 	},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	nonEmptyString: (value: any, propName: string, componentName: string) => {
+	nonEmptyString: (value: unknown, propName: string, componentName: string) => {
 		validators.string(value, propName, componentName);
-		if (value.trim().length === 0) {
+		if (typeof value === "string" && value.trim().length === 0) {
 			throw new PropValidationError(componentName, propName, "Cannot be empty");
 		}
 	},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	boolean: (value: any, propName: string, componentName: string) => {
+	boolean: (value: unknown, propName: string, componentName: string) => {
 		if (typeof value !== "boolean") {
 			throw new PropValidationError(componentName, propName, "Must be a boolean");
 		}
 	},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	function: (value: any, propName: string, componentName: string) => {
+	function: (value: unknown, propName: string, componentName: string) => {
 		if (typeof value !== "function") {
 			throw new PropValidationError(componentName, propName, "Must be a function");
 		}
 	},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	array: (value: any, propName: string, componentName: string) => {
+	array: (value: unknown, propName: string, componentName: string) => {
 		if (!Array.isArray(value)) {
 			throw new PropValidationError(componentName, propName, "Must be an array");
 		}
 	},
 
-	// biome-ignore lint/suspicious/noExplicitAny: Validator needs to accept any value type
-	nonEmptyArray: (value: any, propName: string, componentName: string) => {
+	nonEmptyArray: (value: unknown, propName: string, componentName: string) => {
 		validators.array(value, propName, componentName);
-		if (value.length === 0) {
+		if (Array.isArray(value) && value.length === 0) {
 			throw new PropValidationError(componentName, propName, "Cannot be empty");
 		}
 	},
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: Generic validation function needs flexible types
-export function validateProps<T extends Record<string, any>>(
+type Validator = (value: unknown, propName: string, componentName: string) => void;
+
+export function validateProps<T extends Record<string, unknown>>(
 	props: T,
-	validationRules: Partial<
-		// biome-ignore lint/suspicious/noExplicitAny: Validator function signature
-		Record<keyof T, (value: any, propName: string, componentName: string) => void>
-	>,
+	validationRules: Partial<Record<keyof T, Validator>>,
 	componentName: string,
 ) {
 	for (const propName in validationRules) {


### PR DESCRIPTION
## Summary
- Replaced all `any` types with `unknown` in the validation utility for improved type safety
- The codebase already had minimal `any` usage - only 10 occurrences in one file

## Changes

### File Modified: `packages/bgui/src/utils/validation.ts`

1. **Replaced `any` with `unknown`** in all validator functions:
   - `required`, `number`, `string`, `nonEmptyString`, `boolean`, `function`, `array`, `nonEmptyArray`
   - Changed parameter types from `(value: any, ...)` to `(value: unknown, ...)`

2. **Updated generic constraints**:
   - Changed `Record<string, any>` to `Record<string, unknown>`
   - Updated validator function signatures

3. **Added type safety**:
   - Added proper type guards (`typeof value === "string"`, `Array.isArray(value)`)
   - Used type assertion for `oneOf` validator: `value as T`
   - Introduced `Validator` type alias for cleaner code

## Results
- **Before**: 10 occurrences of `any` type
- **After**: 0 occurrences of `any` type
- Zero breaking changes
- All type checks pass
- Better compile-time error detection

## Test Plan
- [x] Run `pnpm typecheck` - All types pass
- [x] Run `pnpm lint` - Code properly formatted
- [x] Verify validators still work correctly
- [ ] Test component prop validation in development mode

## Benefits
1. Improved type safety without sacrificing functionality
2. Forces proper type checking before using values
3. Better developer experience with compile-time error detection
4. No runtime impact - changes are purely for type safety

🤖 Generated with [Claude Code](https://claude.ai/code)