### PR TITLE
Implement email submission in website

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-	/* config options here */
+	reactStrictMode: true,
 };
 
 export default nextConfig;

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -24,7 +24,9 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="en">
-			<body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+			<body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+				<main>{children}</main>
+			</body>
 		</html>
 	);
 }

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { Button, GlowingLogo, Link, Text, TextInput, View } from "@braingame/bgui";
 import { useState } from "react";
+import { submitEmail } from "../lib/emailService";
 
 export default function HomePage() {
 	const [email, setEmail] = useState("");
@@ -9,19 +10,15 @@ export default function HomePage() {
 	const [submitMessage, setSubmitMessage] = useState("");
 
 	const handleSubmit = async () => {
-		if (!email || !email.includes("@")) {
-			setSubmitMessage("Please enter a valid email address");
-			return;
-		}
-
 		setIsSubmitting(true);
 		setSubmitMessage("");
 
 		try {
-			// TODO: Implement Firebase integration
-			await new Promise((resolve) => setTimeout(resolve, 1000)); // Simulate API call
-			setSubmitMessage("Thanks! We'll notify you when we launch.");
-			setEmail("");
+			const result = await submitEmail(email);
+			setSubmitMessage(result.message);
+			if (result.success) {
+				setEmail("");
+			}
 		} catch (_error) {
 			setSubmitMessage("Something went wrong. Please try again.");
 		} finally {


### PR DESCRIPTION
## Summary
- integrate `submitEmail` into the home page
- add `<main>` wrapper in root layout
- enable React strict mode

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm typecheck` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6856f98c95e483208b209c80c3220a61