### PR TITLE
Add enterprise readiness docs

### DIFF
--- a/docs/ENTERPRISE_READINESS.md
+++ b/docs/ENTERPRISE_READINESS.md
@@ -1,0 +1,32 @@
+# Enterprise Readiness Guide
+
+This document summarizes the practices that help keep the Brain Game monorepo ready for enterprise use.
+
+## Monorepo Management
+- **Turborepo** organizes apps and packages with a unified task graph.
+- Atomic commits and shared caching keep builds reproducible.
+
+## Quality Gates
+- **Zero tolerance** policy for lint and type errors.
+- Mandatory pre‑commit hooks run `pnpm lint` and `pnpm typecheck`.
+- Tests run with `pnpm test` in CI before any merge.
+
+## CI / CD Pipeline
+1. **lint** → Biome and dependency graph checks
+2. **test** → unit and e2e suites
+3. **build** → Turbo cache and artifact upload
+4. **deploy** → preview on Vercel and Expo
+5. **release** → publish packages with Changesets
+
+## Security
+- Secrets are stored only in the CI provider’s secret manager.
+- TruffleHog scans commits for accidental secrets.
+
+## Workspace Isolation
+- Multiple git worktrees separate production code from experiments.
+- Always verify the current worktree with `git worktree list`.
+
+## Caching
+- Optional remote caching (e.g. Vercel) speeds up CI across pull requests.
+
+_End of file_

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@
 | [`QUALITY_ROADMAP.md`](./QUALITY_ROADMAP.md) | The strategic roadmap for all engineering quality initiatives. |
 | [`LESSONS.md`](./LESSONS.md) | Consolidated technical learnings, patterns, and solutions from development. |
 | [`AGENTS.md`](./AGENTS.md) | The high-level policy document defining roles for AI agents. |
+| [`ENTERPRISE_READINESS.md`](./ENTERPRISE_READINESS.md) | Overview of our enterprise practices and CI pipeline. |
 
 ---
 


### PR DESCRIPTION
## Summary
- document key enterprise features in `ENTERPRISE_READINESS.md`
- link the new guide from the documentation hub

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm typecheck` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_e_6856f94862e88320b480096d075c31d3