### PR TITLE
Add i18n package and docs

### DIFF
--- a/docs/BGUI_COMPONENT_PLAN.md
+++ b/docs/BGUI_COMPONENT_PLAN.md
@@ -18,6 +18,10 @@ All components support:
 - Screen reader compatibility with semantic markup
 - Focus trapping for overlays (Modal, Menu, etc.)
 
+### Internationalization (i18n)
+All user facing strings and ARIA labels should come from translation files managed by the shared `@braingame/i18n` package. Components reference translation keys so content can be localized without code changes.
+See [I18N_WORKFLOW.md](./I18N_WORKFLOW.md) for steps to add a new language.
+
 ### Theming Strategy
 Components consume design tokens from a central theme:
 ```typescript

--- a/docs/I18N_WORKFLOW.md
+++ b/docs/I18N_WORKFLOW.md
@@ -1,0 +1,25 @@
+# Internationalization Workflow
+
+> Updated: 20-06-2025
+
+Brain Game uses **i18next** to manage translations for all packages and apps. The shared configuration lives in the `@braingame/i18n` package.
+
+---
+
+## Adding a New Language
+
+1. **Create a locale folder** inside `packages/i18n/src/locales/` with the language code.
+   ```
+   packages/i18n/src/locales/fr/common.json
+   ```
+2. **Add translation strings** in the new JSON file using the existing keys.
+3. **Register the language** in `packages/i18n/src/index.ts` by importing the file and adding it to the `resources` object.
+4. Run `pnpm lint` and `pnpm typecheck` to ensure the repository remains error free.
+
+### ARIA Labels
+
+All ARIA labels and user facing text should be defined in translation files. Components must reference these keys so screen readers announce the correct localized strings.
+
+---
+
+For further guidance on component accessibility requirements see `docs/BGUI_COMPONENT_PLAN.md`.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@braingame/i18n",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Shared i18next configuration for Brain Game",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsc",
+		"lint": "biome check --fix --vcs-root=../..",
+		"typecheck": "tsc --noEmit",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"i18next": "^23.10.1",
+		"react-i18next": "^14.0.0"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0 || ^19.0.0",
+		"react-native": "0.76.3"
+	}
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,0 +1,18 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "./locales/en/common.json";
+import es from "./locales/es/common.json";
+
+export const supportedLanguages = ["en", "es"] as const;
+
+void i18n.use(initReactI18next).init({
+	resources: {
+		en: { translation: en },
+		es: { translation: es },
+	},
+	lng: "en",
+	fallbackLng: "en",
+	interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -1,0 +1,4 @@
+{
+	"welcome": "Welcome",
+	"hello": "Hello"
+}

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -1,0 +1,4 @@
+{
+	"welcome": "Bienvenido",
+	"hello": "Hola"
+}

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../config/tsconfig.base.json",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"outDir": "./dist",
+		"declaration": true,
+		"declarationMap": true
+	},
+	"include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,21 @@ importers:
 
   packages/config: {}
 
+  packages/i18n:
+    dependencies:
+      i18next:
+        specifier: ^23.10.1
+        version: 23.16.8
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-i18next:
+        specifier: ^14.0.0
+        version: 14.1.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react-native@0.76.3(@babel/core@7.27.4)(@babel/preset-env@7.27.2(@babel/core@7.27.4))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native:
+        specifier: 0.76.3
+        version: 0.76.3(@babel/core@7.27.4)(@babel/preset-env@7.27.2(@babel/core@7.27.4))(@types/react@19.0.14)(react@19.0.0)
+
   packages/utils:
     dependencies:
       react:
@@ -5067,6 +5082,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -5108,6 +5126,9 @@ packages:
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
+  i18next@23.16.8:
+    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -6820,6 +6841,19 @@ packages:
     peerDependencies:
       react: 19.0.0
 
+  react-i18next@14.1.3:
+    resolution: {integrity: sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==}
+    peerDependencies:
+      i18next: '>= 23.2.3'
+      react: 19.0.0
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -8016,6 +8050,10 @@ packages:
 
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -14329,6 +14367,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -14377,6 +14419,10 @@ snapshots:
   husky@9.1.7: {}
 
   hyphenate-style-name@1.1.0: {}
+
+  i18next@23.16.8:
+    dependencies:
+      '@babel/runtime': 7.27.6
 
   iconv-lite@0.4.24:
     dependencies:
@@ -16801,6 +16847,16 @@ snapshots:
     dependencies:
       react: 19.0.0
 
+  react-i18next@14.1.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react-native@0.76.3(@babel/core@7.27.4)(@babel/preset-env@7.27.2(@babel/core@7.27.4))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      html-parse-stringify: 3.0.1
+      i18next: 23.16.8
+      react: 19.0.0
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
+      react-native: 0.76.3(@babel/core@7.27.4)(@babel/preset-env@7.27.2(@babel/core@7.27.4))(@types/react@19.0.14)(react@19.0.0)
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -18204,6 +18260,8 @@ snapshots:
       - yaml
 
   vlq@1.0.1: {}
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add `@braingame/i18n` package using i18next
- provide sample translations for English and Spanish
- document workflow for adding languages
- mention ARIA/i18n policy in component plan

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm typecheck` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6857b14d02248320b114c12cc4dc66bd