### PR TITLE
Add desktop outline and feature flags docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,8 +158,11 @@ All AI agents **MUST**:
 
 ## 10. Extension points
 
-- **Add platform**: create `apps/desktop` (Electron/Tauri) – same folder contract.  
-- **Extract UI kit**: move `packages/bgui` to its own repo; replace workspace dep with npm.  
+- **Add platform**: create `apps/desktop` (Electron/Tauri).
+  - Mirror `apps/product` structure (`src/`, `public/`, config files).
+  - Package with Tauri CLI to produce signed `.dmg`/`.exe` installers.
+  - Publish installers via GitHub Releases with auto‑update enabled.
+- **Extract UI kit**: move `packages/bgui` to its own repo; replace workspace dep with npm.
 - **Feature flags**: insert LaunchDarkly wrapper in `packages/utils`.
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -220,6 +220,10 @@
    - Add performance monitoring
    - Set up Sentry for error tracking
 
+## 🔌 Extension Points
+- Plan new `apps/desktop` using Tauri with GitHub Release distribution.
+- Add LaunchDarkly feature flag wrapper in `packages/utils`.
+
 ## ✅ Completed (Latest First)
 
 - [x] Worktree Management & Documentation (20-01-2025)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -26,6 +26,23 @@ pnpm add @braingame/utils
 - Icon sizing utilities
 - Task management functions
 
+### Feature Flags
+Use LaunchDarkly to control experimental features across apps.
+
+```env
+REACT_APP_LD_CLIENT_ID="your-client-id"
+REACT_APP_LD_USER_KEY="anonymous-user"
+```
+
+```ts
+import { ldClient } from "@braingame/utils/featureFlags";
+
+await ldClient.waitForInitialization();
+if (ldClient.variation("new-ui", false)) {
+    // feature-specific logic
+}
+```
+
 ## Documentation
 
 - [Architecture](../../docs/ARCHITECTURE.md) - System design


### PR DESCRIPTION
## Summary
- detail folder structure and deployment for future apps/desktop
- document LaunchDarkly usage in `@braingame/utils`
- list extension plans in TODO tracker

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm typecheck` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6857ba82bc84832090b3ad755dec2984