### PR TITLE
Fix: Replace hardcoded app version in ErrorService.ts with dynamic version

### DIFF
--- a/apps/product/src/services/ErrorService.ts
+++ b/apps/product/src/services/ErrorService.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import Constants from "expo-constants";
 import { Platform } from "react-native";
 
 interface ErrorContext {
@@ -117,7 +118,7 @@ class ErrorService {
 				sessionId: this.sessionId,
 			},
 			platform: Platform.OS,
-			appVersion: "1.0.0", // TODO: Get from app config
+			appVersion: Constants.expoConfig?.version || "unknown",
 			deviceInfo: {
 				os: Platform.OS,
 				osVersion: Platform.Version?.toString() || "unknown",


### PR DESCRIPTION
## Summary
- Replace hardcoded "1.0.0" with `Constants.expoConfig?.version`
- Add expo-constants import for accessing app configuration
- Use proper fallback to "unknown" if version unavailable
- Resolves TODO comment and improves error tracking accuracy

## Test plan
- [x] Import Constants from expo-constants
- [x] Replace hardcoded version with dynamic version from expo config
- [x] Add proper fallback if version is unavailable
- [x] Verify error logs will now include actual app version

This addresses the hardcoded version concern listed in TODO.md critical bugs.

🤖 Generated with [Claude Code](https://claude.ai/code)