### PR TITLE
fix: restore accidentally removed Lighthouse CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,219 @@ jobs:
       
       - name: Run type checking
         run: pnpm typecheck
+
+  lighthouse:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli@0.13.x
+      
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      
+      # Main Site
+      - name: Start main-site server
+        run: |
+          cd apps/main-site
+          PORT=3000 pnpm start &
+          echo $! > /tmp/main-site.pid
+          npx wait-on http://localhost:3000 --timeout 60000
+      
+      - name: Run Lighthouse CI for Main Site
+        run: |
+          lhci autorun \
+            --config=./lighthouse/main-site.config.js \
+            || echo "Main Site Lighthouse CI assertions failed, but continuing"
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Stop main-site server
+        if: always()
+        run: |
+          if [ -f /tmp/main-site.pid ]; then
+            kill $(cat /tmp/main-site.pid) || true
+          fi
+      
+      # Docs Site
+      - name: Start docs-site server
+        run: |
+          cd apps/docs-site
+          PORT=3001 pnpm start &
+          echo $! > /tmp/docs-site.pid
+          npx wait-on http://localhost:3001 --timeout 60000
+      
+      - name: Run Lighthouse CI for Docs Site
+        run: |
+          lhci autorun \
+            --config=./lighthouse/docs-site.config.js \
+            || echo "Docs Site Lighthouse CI assertions failed, but continuing"
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Stop docs-site server
+        if: always()
+        run: |
+          if [ -f /tmp/docs-site.pid ]; then
+            kill $(cat /tmp/docs-site.pid) || true
+          fi
+      
+      # Product Web
+      - name: Start product web server
+        run: |
+          cd apps/product
+          npx expo start --web --port 8081 &
+          echo $! > /tmp/product-web.pid
+          npx wait-on http://localhost:8081 --timeout 90000
+      
+      - name: Run Lighthouse CI for Product Web
+        run: |
+          lhci autorun \
+            --config=./lighthouse/product-web.config.js \
+            || echo "Product Web Lighthouse CI assertions failed, but continuing"
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Stop product web server
+        if: always()
+        run: |
+          if [ -f /tmp/product-web.pid ]; then
+            kill $(cat /tmp/product-web.pid) || true
+          fi
+      
+      - name: Comment PR with Lighthouse results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            
+            // Read the Lighthouse results
+            const resultsPath = '.lighthouseci';
+            if (!fs.existsSync(resultsPath)) {
+              console.log('No Lighthouse results found');
+              return;
+            }
+            
+            // Find all manifest files
+            const files = fs.readdirSync(resultsPath);
+            const manifestFiles = files.filter(f => f.startsWith('manifest.'));
+            
+            if (manifestFiles.length === 0) {
+              console.log('No manifest files found');
+              return;
+            }
+            
+            // Group results by site
+            const siteResults = {
+              'Main Site': [],
+              'Docs Site': [],
+              'Product Web': []
+            };
+            
+            // Process all manifest files
+            for (const manifestFile of manifestFiles) {
+              try {
+                const manifest = JSON.parse(
+                  fs.readFileSync(path.join(resultsPath, manifestFile), 'utf8')
+                );
+                
+                for (const [url, runs] of Object.entries(manifest)) {
+                  if (!runs || runs.length === 0) {
+                    console.log(`No runs found for URL: ${url}`);
+                    continue;
+                  }
+                  
+                  const latestRun = runs[runs.length - 1];
+                  
+                  // Categorize by port
+                  let siteName = 'Unknown';
+                  if (url.includes(':3000')) siteName = 'Main Site';
+                  else if (url.includes(':3001')) siteName = 'Docs Site';
+                  else if (url.includes(':8081')) siteName = 'Product Web';
+                  
+                  if (siteResults[siteName]) {
+                    siteResults[siteName].push({ url, summary: latestRun.summary });
+                  }
+                }
+              } catch (error) {
+                console.error(`Error processing manifest file ${manifestFile}:`, error);
+              }
+            }
+            
+            // Format the results as a comment
+            let comment = '## 🏠 Lighthouse CI Results\n\n';
+            
+            for (const [siteName, results] of Object.entries(siteResults)) {
+              if (results.length === 0) continue;
+              
+              comment += `### ${siteName}\n\n`;
+              
+              // Average scores across all pages for this site
+              const avgScores = {
+                performance: 0,
+                accessibility: 0,
+                'best-practices': 0,
+                seo: 0
+              };
+              
+              results.forEach(({ summary }) => {
+                avgScores.performance += summary.performance;
+                avgScores.accessibility += summary.accessibility;
+                avgScores['best-practices'] += summary['best-practices'];
+                avgScores.seo += summary.seo;
+              });
+              
+              const count = results.length;
+              comment += '| Category | Average Score |\n';
+              comment += '| --- | --- |\n';
+              comment += `| Performance | ${Math.round(avgScores.performance / count * 100)}% |\n`;
+              comment += `| Accessibility | ${Math.round(avgScores.accessibility / count * 100)}% |\n`;
+              comment += `| Best Practices | ${Math.round(avgScores['best-practices'] / count * 100)}% |\n`;
+              comment += `| SEO | ${Math.round(avgScores.seo / count * 100)}% |\n\n`;
+              
+              // Show individual page results
+              comment += '<details>\n<summary>View page details</summary>\n\n';
+              results.forEach(({ url, summary }) => {
+                const pagePath = new URL(url).pathname;
+                comment += `**${pagePath}**: `;
+                comment += `P:${Math.round(summary.performance * 100)}% `;
+                comment += `A:${Math.round(summary.accessibility * 100)}% `;
+                comment += `BP:${Math.round(summary['best-practices'] * 100)}% `;
+                comment += `SEO:${Math.round(summary.seo * 100)}%\n`;
+              });
+              comment += '\n</details>\n\n';
+            }
+            
+            // Post the comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: comment,
+            });
+      
+      - name: Save Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-results
+          path: .lighthouseci/


### PR DESCRIPTION
## Summary

During the merge of PR #173 (Reassure performance testing), the entire Lighthouse CI job was accidentally removed from the CI workflow. This PR restores it.

## What happened
- PR #173 was merged which added Reassure performance testing
- During the merge, the Lighthouse CI job (over 200 lines) was completely removed from 
- This means we lost performance monitoring for all three web applications

## What this fixes
- Restores the complete Lighthouse CI job configuration
- Re-enables performance monitoring for:
  - Main Site (marketing site)
  - Docs Site (documentation)
  - Product Web (Expo web version)
- Maintains all the improvements from PR #172 (multi-site configuration, error handling, etc.)

## Impact
Critical - without this, we have no performance monitoring in CI