### PR TITLE
Add internal DX audit summary

### DIFF
--- a/INTERNAL_DX_AUDIT-e24beef4-7c35-45ea-8975-bddf5aa19f21.md
+++ b/INTERNAL_DX_AUDIT-e24beef4-7c35-45ea-8975-bddf5aa19f21.md
@@ -1,0 +1,22 @@
+# Internal DX Audit - Brain Game
+
+**Internal Friction Index:** 6/10
+
+## Observations
+- The repository includes extensive CLI scripts for component scaffolding and development utilities as described in `scripts/README.md`.
+- Morgan is used for request logging and the API README explains how to start the service using `pnpm`.
+- Firebase setup instructions outline how to deploy Firestore rules and run local emulators for testing.
+- Firestore security rules restrict email signup documents to write-only access, blocking reads from client apps.
+- The development guide details manual environment setup and dependency installation with `pnpm`.
+- `TODO.md` sets a test coverage goal of **90%**, signalling a push to improve overall test completeness.
+
+## Recommendations
+- Improve CLI documentation for faster onboarding of new support engineers.
+- Add redaction controls for sensitive data to enhance compliance.
+- Expand audit logging and permission scopes for better observability.
+- Increase automated test coverage and simplify setup scripts.
+
+## Scaling Operations Plan
+- Allocate headcount for a dedicated DevOps engineer to own CI/CD and internal tooling.
+- Cross-train support staff on the admin panel and dashboard features to resolve issues without developer intervention.
+- Schedule periodic DX reviews to track friction index improvements and adjust staffing as needed.


### PR DESCRIPTION
## Summary
- add internal DX audit summary with friction index and ops recommendations

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm typecheck` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685afaa142a483209ab8e5baaffbba0f