### PR TITLE
docs: add OSS contribution review

### DIFF
--- a/prompts_output/OSS_CONTRIBUTION_REVIEW-46be8908-e00e-4739-8f51-db95367e622c.md
+++ b/prompts_output/OSS_CONTRIBUTION_REVIEW-46be8908-e00e-4739-8f51-db95367e622c.md
@@ -1,0 +1,17 @@
+# OSS Contribution Review
+
+Friction Score: 4/10
+
+## Findings
+- `CONTRIBUTING.md` mandates running `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` before opening a PR and enforces Conventional Commits.
+- PR template references `npm` commands rather than `pnpm`, which may confuse contributors.
+- README offers a pnpm-based quick start with quality gate explanation.
+- Bug and feature issue templates exist but omit trailing newlines and provide minimal guidance.
+- Weekly Dependabot configuration keeps dependencies updated automatically.
+
+## First PR in 30 Minutes Plan
+1. Fork and clone the repo, then run `pnpm install`.
+2. Create a branch and update `.github/PULL_REQUEST_TEMPLATE.md` to use `pnpm` commands.
+3. Run `pnpm lint`, `pnpm typecheck`, and `pnpm test` (may fail without full environment).
+4. Commit with a Conventional Commit message like `docs(contributing): use pnpm commands in PR template`.
+5. Open a PR describing the change and reference this review file.


### PR DESCRIPTION
## Summary
- add contribution review with friction score and first-PR plan

## Testing
- `pnpm lint` *(fails: pnpm tried to fetch from registry)*
- `pnpm typecheck` *(fails: pnpm tried to fetch from registry)*
- `pnpm test` *(fails: pnpm tried to fetch from registry)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685cf55755888320826456e89ad1b19d