### PR TITLE
docs: update PR template to reference pnpm commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@ Provide a short summary of your changes.
 Explain how you tested your changes.
 
 ## Checklist
-- [ ] Lint and type checks pass
-- [ ] Tests pass
+- [ ] Ran `pnpm lint` - no errors or warnings
+- [ ] Ran `pnpm typecheck` - no errors
+- [ ] Ran `pnpm test` - all tests pass
+- [ ] Ran `pnpm build` - builds successfully
 - [ ] Documentation updated if needed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Enable version updates for npm
+  # Enable version updates for JavaScript dependencies (works with pnpm)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Updated PR template checklist to explicitly reference pnpm commands
- Added clarifying comment to dependabot.yml that it works with pnpm
- Helps contributors understand the correct commands to run

## Changes
- `.github/PULL_REQUEST_TEMPLATE.md`: Updated checklist with explicit pnpm commands
- `.github/dependabot.yml`: Added comment clarifying pnpm compatibility

This addresses the developer experience issue identified in the audit about npm references in documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)